### PR TITLE
monthly + annual aggregate views for state and zip3

### DIFF
--- a/migrations/001_create_medicaid_schema.sql
+++ b/migrations/001_create_medicaid_schema.sql
@@ -1,17 +1,7 @@
 /*
  * Medicaid Schema Definition
  * 
- * This script creates the medicaid schema containing a normalized dimensional data model
- * for Medicaid dental provider spending and utilization data. The schema includes:
- * 
- * - providers: Dimension table for provider information (NPIs)
- * - procedures: Dimension table for HCPCS procedure codes
- * - months: Time dimension table for year-month periods
- * - provider_spending: Fact table with spending metrics, claims, and beneficiary counts
- *   (tracks both servicing and billing NPIs for dental procedures)
- *
- *
- * IMPORTANT: - provider_spending_staging: Staging table for data import/ETL
+ * IMPORTANT: - provider_spending_raw: Staging table for data import/ETL
  * 
  * This is designed to support analysis of dental provider utilization patterns,
  * spending trends, and beneficiary access to dental services under Medicaid.
@@ -20,54 +10,9 @@
 CREATE SCHEMA IF NOT EXISTS medicaid;
 SET search_path TO medicaid;
 
--- Providers (billing and servicing NPIs both reference this)
-CREATE TABLE providers (
-    npi                 VARCHAR(10) PRIMARY KEY,
-    provider_name       TEXT,
-    provider_type       TEXT,
-    created_at          TIMESTAMPTZ DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ DEFAULT NOW()
-);
+DROP TABLE IF EXISTS medicaid.provider_spending_raw;
 
--- Procedure codes (HCPCS)
-CREATE TABLE procedures (
-    hcpcs_code          VARCHAR(10) PRIMARY KEY,
-    description         TEXT,
-    category            TEXT,
-    created_at          TIMESTAMPTZ DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ DEFAULT NOW()
-);
-
--- Month dimension (YYYY‑MM)
-CREATE TABLE months (
-    month_id            SERIAL PRIMARY KEY,
-    year                INTEGER NOT NULL,
-    month               INTEGER NOT NULL CHECK (month BETWEEN 1 AND 12),
-    month_start_date    DATE NOT NULL,
-    month_end_date      DATE NOT NULL,
-    UNIQUE (year, month)
-);
-
-CREATE TABLE provider_spending (
-    id                          BIGSERIAL PRIMARY KEY,
-
-    servicing_npi               VARCHAR(10) NOT NULL REFERENCES providers(npi),
-    billing_npi                 VARCHAR(10) NOT NULL REFERENCES providers(npi),
-
-    hcpcs_code                  VARCHAR(10) NOT NULL REFERENCES procedures(hcpcs_code),
-    month_id                    INTEGER NOT NULL REFERENCES months(month_id),
-
-    beneficiaries_served_count  INTEGER NOT NULL CHECK (beneficiaries_served_count >= 0),
-    claims_count                INTEGER NOT NULL CHECK (claims_count >= 0),
-    total_amount_paid           NUMERIC(18,2) NOT NULL CHECK (total_amount_paid >= 0),
-
-    load_timestamp              TIMESTAMPTZ DEFAULT NOW(),
-
-    -- Uniqueness based on the dataset’s grain:
-    UNIQUE (servicing_npi, billing_npi, hcpcs_code, month_id)
-);
-
-CREATE TABLE medicaid.provider_spending_staging (
+CREATE TABLE medicaid.provider_spending_raw (
     servicing_npi               VARCHAR(10),
     billing_npi                 VARCHAR(10),
     hcpcs_code                  VARCHAR(10),

--- a/migrations/002_create_nppes_schema.sql
+++ b/migrations/002_create_nppes_schema.sql
@@ -15,9 +15,9 @@
 
 CREATE SCHEMA IF NOT EXISTS nppes;
 
-DROP TABLE IF EXISTS nppes.npi_staging;
+DROP TABLE IF EXISTS nppes.npi_raw;
 
-CREATE TABLE nppes.npi_staging (
+CREATE TABLE nppes.npi_raw (
 
     -- ============================
     -- Core Provider Identification

--- a/migrations/004_add_staging_join_indexes.sql
+++ b/migrations/004_add_staging_join_indexes.sql
@@ -1,7 +1,7 @@
 -- add indexes used during staging joins
 -- improves performance when joining provider_spending_staging to nppes.npi_staging
-CREATE INDEX idx_spending_servicing_npi
-ON medicaid.provider_spending_staging(servicing_npi);
+CREATE INDEX idx_spending_raw_servicing_npi
+ON medicaid.provider_spending_raw(servicing_npi);
 
-CREATE INDEX idx_npi_staging_npi
-ON nppes.npi_staging(npi);
+CREATE INDEX idx_npi_raw_npi
+ON nppes.npi_raw(npi);

--- a/migrations/005_populate_provider_procedure_monthly_geo.sql
+++ b/migrations/005_populate_provider_procedure_monthly_geo.sql
@@ -12,7 +12,7 @@ SELECT
     n.provider_business_practice_location_address_state_name   AS state,
     n.provider_business_practice_location_address_postal_code  AS zip_code_5,
     n.provider_business_practice_location_address_country_code AS country_code
-FROM medicaid.provider_spending_staging p
-JOIN nppes.npi_staging n
+FROM medicaid.provider_spending_raw p
+JOIN nppes.npi_raw n
   ON p.servicing_npi = n.npi::text
 WHERE p.hcpcs_code LIKE 'D%';

--- a/migrations/aggregate_views/006_create_procedure_category_aggregate_view.sql
+++ b/migrations/aggregate_views/006_create_procedure_category_aggregate_view.sql
@@ -1,0 +1,80 @@
+-- aggregate combined table by zip5, billing code, and year_month
+-- cast hcpcs_code to category based on below range
+-- Category | Code Range
+
+-- Diagnostic | D0100–D0999
+-- Preventive | D1000–D1999
+-- Restorative | D2000–D2999
+-- Endodontics | D3000–D3999
+-- Periodontics | D4000–D4999
+-- Prosthodontics (removable) | D5000–D5899
+-- Maxillofacial Prosthetics | D5900–D5999
+-- Implant Services | D6000–D6199
+-- Prosthodontics (fixed) | D6200–D6999
+-- Oral Surgery | D7000–D7999
+-- Orthodontics | D8000–D8999
+-- Adjunctive General Services | D9000–D9999
+CREATE OR REPLACE VIEW medicaid.provider_procedure_category_aggregate AS
+WITH cleaned AS (
+    SELECT
+        LEFT(NULLIF(TRIM(zip_code_5), ''), 5) AS zip5,
+        state,
+        year_month,
+        beneficiaries_served_count,
+        claims_count,
+        total_amount_paid,
+
+        -- Extract numeric portion safely (handles codes like D1234)
+        CASE
+            WHEN hcpcs_code ~ '^D[0-9]{4}$'
+            THEN SUBSTRING(hcpcs_code FROM 2 FOR 4)::int
+            ELSE NULL
+        END AS hcpcs_numeric
+    FROM medicaid.provider_procedure_monthly_geo
+),
+categorized AS (
+    SELECT
+        zip5,
+        state,
+        year_month,
+        beneficiaries_served_count,
+        claims_count,
+        total_amount_paid,
+
+        CASE
+            WHEN hcpcs_numeric BETWEEN 100 AND 999   THEN 'Diagnostic'
+            WHEN hcpcs_numeric BETWEEN 1000 AND 1999 THEN 'Preventive'
+            WHEN hcpcs_numeric BETWEEN 2000 AND 2999 THEN 'Restorative'
+            WHEN hcpcs_numeric BETWEEN 3000 AND 3999 THEN 'Endodontics'
+            WHEN hcpcs_numeric BETWEEN 4000 AND 4999 THEN 'Periodontics'
+            WHEN hcpcs_numeric BETWEEN 5000 AND 5899 THEN 'Prosthodontics (removable)'
+            WHEN hcpcs_numeric BETWEEN 5900 AND 5999 THEN 'Maxillofacial Prosthetics'
+            WHEN hcpcs_numeric BETWEEN 6000 AND 6199 THEN 'Implant Services'
+            WHEN hcpcs_numeric BETWEEN 6200 AND 6999 THEN 'Prosthodontics (fixed)'
+            WHEN hcpcs_numeric BETWEEN 7000 AND 7999 THEN 'Oral Surgery'
+            WHEN hcpcs_numeric BETWEEN 8000 AND 8999 THEN 'Orthodontics'
+            WHEN hcpcs_numeric BETWEEN 9000 AND 9999 THEN 'Adjunctive General Services'
+            ELSE 'Uncategorized'
+        END AS category
+    FROM cleaned
+)
+
+SELECT
+    zip5,
+    state,
+    year_month,
+    category,
+    SUM(beneficiaries_served_count) AS total_beneficiaries_served,
+    SUM(claims_count) AS total_claims,
+    SUM(total_amount_paid) AS total_amount_paid
+FROM categorized
+GROUP BY
+    zip5,
+    state,
+    year_month,
+    category
+ORDER BY
+    zip5,
+    state,
+    year_month,
+    category;

--- a/migrations/aggregate_views/007_create_procedure_category_aggregate_monthly_state_view.sql
+++ b/migrations/aggregate_views/007_create_procedure_category_aggregate_monthly_state_view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW medicaid.provider_procedure_category_aggregate_monthly_state AS
+SELECT
+    state,
+    year_month,
+    category,
+    SUM(total_beneficiaries_served) AS total_beneficiaries_served,
+    SUM(total_claims) AS total_claims,
+    SUM(total_amount_paid) AS total_amount_paid
+FROM medicaid.provider_procedure_category_aggregate
+GROUP BY
+    state,
+    year_month,
+    category
+ORDER BY
+    state,
+    year_month,
+    category;

--- a/migrations/aggregate_views/008_create_procedure_category_aggregate_annual_state_view.sql
+++ b/migrations/aggregate_views/008_create_procedure_category_aggregate_annual_state_view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW medicaid.provider_procedure_category_aggregate_annual_state AS
+SELECT
+    state,
+    LEFT(year_month, 4) AS year,
+    category,
+    SUM(total_beneficiaries_served) AS total_beneficiaries_served,
+    SUM(total_claims) AS total_claims,
+    SUM(total_amount_paid) AS total_amount_paid
+FROM medicaid.provider_procedure_category_aggregate
+GROUP BY
+    state,
+    year,
+    category
+ORDER BY
+    state,
+    year,
+    category;

--- a/migrations/aggregate_views/009_create_procedure_category_aggregate_monthly_zip3_view.sql
+++ b/migrations/aggregate_views/009_create_procedure_category_aggregate_monthly_zip3_view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW medicaid.provider_procedure_category_aggregate_monthly_zip3 AS
+SELECT
+    LEFT(NULLIF(TRIM(zip5), ''), 3) AS zip3,
+    year_month,
+    category,
+    SUM(total_beneficiaries_served) AS total_beneficiaries_served,
+    SUM(total_claims) AS total_claims,
+    SUM(total_amount_paid) AS total_amount_paid
+FROM medicaid.provider_procedure_category_aggregate
+GROUP BY
+    zip3,
+    year_month,
+    category
+ORDER BY
+    zip3,
+    year_month,
+    category;

--- a/migrations/aggregate_views/010_create_procedure_category_aggregate_annual_zip3_view.sql
+++ b/migrations/aggregate_views/010_create_procedure_category_aggregate_annual_zip3_view.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE VIEW medicaid.provider_procedure_category_aggregate_annual_zip3 AS
+SELECT
+    LEFT(NULLIF(TRIM(zip5), ''), 3) AS zip3,
+    LEFT(year_month, 4) AS year,
+    category,
+    SUM(total_beneficiaries_served) AS total_beneficiaries_served,
+    SUM(total_claims) AS total_claims,
+    SUM(total_amount_paid) AS total_amount_paid
+FROM medicaid.provider_procedure_category_aggregate
+GROUP BY
+    zip3,
+    year,
+    category
+ORDER BY
+    zip3,
+    year,
+    category;


### PR DESCRIPTION
## Refactor data pipeline: rename staging tables and add aggregate view hierarchy

### Summary

- **Rename staging tables** from `*_staging` to `*_raw` across `medicaid` and `nppes` schemas for
  clearer naming semantics, updating all dependent migrations and indexes accordingly
- **Simplify `medicaid` schema** by removing the premature normalized dimensional model (`providers`,
  `procedures`, `months`, `provider_spending`) in favor of a flat `provider_spending_raw` staging
  table that reflects the actual data pipeline
- **Introduce a versioned aggregate view hierarchy** (`006`–`010`) built on
  `provider_procedure_monthly_geo`, classifying HCPCS dental codes into 12 clinical categories and
  exposing rollups at four granularities:

| Migration | View | Grain |
|-----------|------|-------|
| 006 | `provider_procedure_category_aggregate` | zip5 × state × year_month × category (base) |
| 007 | `provider_procedure_category_aggregate_monthly_state` | state × year_month × category |
| 008 | `provider_procedure_category_aggregate_annual_state` | state × year × category |
| 009 | `provider_procedure_category_aggregate_monthly_zip3` | zip3 × year_month × category |
| 010 | `provider_procedure_category_aggregate_annual_zip3` | zip3 × year × category |

### Test plan

- [ ] Re-run migrations 001–005 against a clean database and verify tables are created under the
      new `*_raw` names
- [ ] Run migrations 006–010 and verify all five views are created without errors
- [ ] Spot-check that `provider_procedure_category_aggregate` returns expected category labels for
      known HCPCS codes
- [ ] Verify state and zip3 rollup views match row counts summed from the base view
- [ ] Confirm annual views correctly collapse 12 months per year into a single row per
      `state`/`zip3` × `category`
