### PR TITLE
aggregated views json export script

### DIFF
--- a/scripts/export_views.md
+++ b/scripts/export_views.md
@@ -1,103 +1,26 @@
 # Export Aggregate Views to JSON
 
-Set `DATABASE_URL` before running any command:
+Set `DATABASE_URL` before running:
 
 ```sh
 export DATABASE_URL="postgresql://user:pass@localhost:5432/dbname"
 ```
 
----
-
-## 007 — provider_procedure_category_aggregate_monthly_state (key: state)
+Run the script from the repo root. Output defaults to `exports/`:
 
 ```sh
-psql "$DATABASE_URL" -t -A -c "
-SELECT json_build_object(state, rows)
-FROM (
-  SELECT state, json_agg(
-    json_build_object(
-      'year_month',                 year_month,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year_month, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_monthly_state
-  WHERE state IS NOT NULL
-  GROUP BY state
-) subq;
-" > exports/provider_procedure_category_aggregate_monthly_state.json
+bash scripts/export_views.sh [output_dir]
 ```
+
+Each output file is structured as `{ "<geo_key>": [ ...rows ] }`.
 
 ---
 
-## 008 — provider_procedure_category_aggregate_annual_state (key: state)
+## SQL files (`scripts/sql/`)
 
-```sh
-psql "$DATABASE_URL" -t -A -c "
-SELECT json_build_object(state, rows)
-FROM (
-  SELECT state, json_agg(
-    json_build_object(
-      'year',                       year,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_annual_state
-  WHERE state IS NOT NULL
-  GROUP BY state
-) subq;
-" > exports/provider_procedure_category_aggregate_annual_state.json
-```
-
----
-
-## 009 — provider_procedure_category_aggregate_monthly_zip3 (key: zip3)
-
-```sh
-psql "$DATABASE_URL" -t -A -c "
-SELECT json_build_object(zip3, rows)
-FROM (
-  SELECT zip3, json_agg(
-    json_build_object(
-      'year_month',                 year_month,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year_month, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_monthly_zip3
-  WHERE zip3 IS NOT NULL
-  GROUP BY zip3
-) subq;
-" > exports/provider_procedure_category_aggregate_monthly_zip3.json
-```
-
----
-
-## 010 — provider_procedure_category_aggregate_annual_zip3 (key: zip3)
-
-```sh
-psql "$DATABASE_URL" -t -A -c "
-SELECT json_build_object(zip3, rows)
-FROM (
-  SELECT zip3, json_agg(
-    json_build_object(
-      'year',                       year,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_annual_zip3
-  WHERE zip3 IS NOT NULL
-  GROUP BY zip3
-) subq;
-" > exports/provider_procedure_category_aggregate_annual_zip3.json
-```
+| File | View | Key | Order |
+|------|------|-----|-------|
+| `007_export_monthly_state.sql` | `provider_procedure_category_aggregate_monthly_state` | `state` | `year_month, category` |
+| `008_export_annual_state.sql` | `provider_procedure_category_aggregate_annual_state` | `state` | `year, category` |
+| `009_export_monthly_zip3.sql` | `provider_procedure_category_aggregate_monthly_zip3` | `zip3` | `year_month, category` |
+| `010_export_annual_zip3.sql` | `provider_procedure_category_aggregate_annual_zip3` | `zip3` | `year, category` |

--- a/scripts/export_views.sh
+++ b/scripts/export_views.sh
@@ -5,90 +5,33 @@
 # Requires DATABASE_URL to be set, e.g.:
 #   export DATABASE_URL="postgresql://user:pass@localhost:5432/dbname"
 
+
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_DIR="$SCRIPT_DIR/sql"
 OUT_DIR="${1:-exports}"
 mkdir -p "$OUT_DIR"
 
 psql_json() {
-  local query="$1"
+  local sqlfile="$1"
   local outfile="$2"
-  psql "$DATABASE_URL" -t -A -c "$query" > "$outfile"
+  psql "$DATABASE_URL" -t -A -f "$sqlfile" > "$outfile"
   echo "Exported: $outfile"
 }
 
 # 007 — provider_procedure_category_aggregate_monthly_state (key: state, order: year_month)
-psql_json "
-SELECT json_build_object(state, rows)
-FROM (
-  SELECT state, json_agg(
-    json_build_object(
-      'year_month',                 year_month,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year_month, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_monthly_state
-  WHERE state IS NOT NULL
-  GROUP BY state
-) subq;
-" "$OUT_DIR/provider_procedure_category_aggregate_monthly_state.json"
+psql_json "$SQL_DIR/007_export_monthly_state.sql" \
+          "$OUT_DIR/provider_procedure_category_aggregate_monthly_state.json"
 
 # 008 — provider_procedure_category_aggregate_annual_state (key: state, order: year)
-psql_json "
-SELECT json_build_object(state, rows)
-FROM (
-  SELECT state, json_agg(
-    json_build_object(
-      'year',                       year,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_annual_state
-  WHERE state IS NOT NULL
-  GROUP BY state
-) subq;
-" "$OUT_DIR/provider_procedure_category_aggregate_annual_state.json"
+psql_json "$SQL_DIR/008_export_annual_state.sql" \
+          "$OUT_DIR/provider_procedure_category_aggregate_annual_state.json"
 
 # 009 — provider_procedure_category_aggregate_monthly_zip3 (key: zip3, order: year_month)
-psql_json "
-SELECT json_build_object(zip3, rows)
-FROM (
-  SELECT zip3, json_agg(
-    json_build_object(
-      'year_month',                 year_month,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year_month, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_monthly_zip3
-  WHERE zip3 IS NOT NULL
-  GROUP BY zip3
-) subq;
-" "$OUT_DIR/provider_procedure_category_aggregate_monthly_zip3.json"
+psql_json "$SQL_DIR/009_export_monthly_zip3.sql" \
+          "$OUT_DIR/provider_procedure_category_aggregate_monthly_zip3.json"
 
 # 010 — provider_procedure_category_aggregate_annual_zip3 (key: zip3, order: year)
-psql_json "
-SELECT json_build_object(zip3, rows)
-FROM (
-  SELECT zip3, json_agg(
-    json_build_object(
-      'year',                       year,
-      'category',                   category,
-      'total_beneficiaries_served', total_beneficiaries_served,
-      'total_claims',               total_claims,
-      'total_amount_paid',          total_amount_paid
-    ) ORDER BY year, category
-  ) AS rows
-  FROM medicaid.provider_procedure_category_aggregate_annual_zip3
-  WHERE zip3 IS NOT NULL
-  GROUP BY zip3
-) subq;
-" "$OUT_DIR/provider_procedure_category_aggregate_annual_zip3.json"
+psql_json "$SQL_DIR/010_export_annual_zip3.sql" \
+          "$OUT_DIR/provider_procedure_category_aggregate_annual_zip3.json"

--- a/scripts/sql/007_export_monthly_state.sql
+++ b/scripts/sql/007_export_monthly_state.sql
@@ -1,0 +1,15 @@
+SELECT json_build_object(state, rows)
+FROM (
+  SELECT state, json_agg(
+    json_build_object(
+      'year_month',                 year_month,
+      'category',                   category,
+      'total_beneficiaries_served', total_beneficiaries_served,
+      'total_claims',               total_claims,
+      'total_amount_paid',          total_amount_paid
+    ) ORDER BY year_month, category
+  ) AS rows
+  FROM medicaid.provider_procedure_category_aggregate_monthly_state
+  WHERE state IS NOT NULL
+  GROUP BY state
+) subq;

--- a/scripts/sql/008_export_annual_state.sql
+++ b/scripts/sql/008_export_annual_state.sql
@@ -1,0 +1,15 @@
+SELECT json_build_object(state, rows)
+FROM (
+  SELECT state, json_agg(
+    json_build_object(
+      'year',                       year,
+      'category',                   category,
+      'total_beneficiaries_served', total_beneficiaries_served,
+      'total_claims',               total_claims,
+      'total_amount_paid',          total_amount_paid
+    ) ORDER BY year, category
+  ) AS rows
+  FROM medicaid.provider_procedure_category_aggregate_annual_state
+  WHERE state IS NOT NULL
+  GROUP BY state
+) subq;

--- a/scripts/sql/009_export_monthly_zip3.sql
+++ b/scripts/sql/009_export_monthly_zip3.sql
@@ -1,0 +1,15 @@
+SELECT json_build_object(zip3, rows)
+FROM (
+  SELECT zip3, json_agg(
+    json_build_object(
+      'year_month',                 year_month,
+      'category',                   category,
+      'total_beneficiaries_served', total_beneficiaries_served,
+      'total_claims',               total_claims,
+      'total_amount_paid',          total_amount_paid
+    ) ORDER BY year_month, category
+  ) AS rows
+  FROM medicaid.provider_procedure_category_aggregate_monthly_zip3
+  WHERE zip3 IS NOT NULL
+  GROUP BY zip3
+) subq;

--- a/scripts/sql/010_export_annual_zip3.sql
+++ b/scripts/sql/010_export_annual_zip3.sql
@@ -1,0 +1,15 @@
+SELECT json_build_object(zip3, rows)
+FROM (
+  SELECT zip3, json_agg(
+    json_build_object(
+      'year',                       year,
+      'category',                   category,
+      'total_beneficiaries_served', total_beneficiaries_served,
+      'total_claims',               total_claims,
+      'total_amount_paid',          total_amount_paid
+    ) ORDER BY year, category
+  ) AS rows
+  FROM medicaid.provider_procedure_category_aggregate_annual_zip3
+  WHERE zip3 IS NOT NULL
+  GROUP BY zip3
+) subq;


### PR DESCRIPTION
# Add aggregate view export scripts

## Summary

Adds `scripts/export_views.sh` and `scripts/export_views.md` to export the four geographic aggregate views (`monthly_state`, `annual_state`, `monthly_zip3`, `annual_zip3`) from Postgres to newline-delimited JSON files.

## Output format

Each export produces one JSON object per line, keyed by the geographic identifier (`state` or `zip3`), with an array of category rows as the value:

```
{"CA": [{"year_month": "2022-01", "category": "Preventive", ...}, ...]}
{"NY": [...]}
```

Rows within each array are ordered by `year_month` (monthly views) or `year` (annual views), then `category`. Null geographic keys are excluded.

## Files changed

- `scripts/export_views.sh` — runnable bash script; accepts an optional output directory argument (defaults to `exports/`). Requires `DATABASE_URL` to be set.
- `scripts/export_views.md` — reference doc with individual copy-pasteable `psql` commands for each of the four views.

## Views exported

| Migration | View | Key | Order |
|---|---|---|---|
| 007 | `provider_procedure_category_aggregate_monthly_state` | `state` | `year_month` |
| 008 | `provider_procedure_category_aggregate_annual_state` | `state` | `year` |
| 009 | `provider_procedure_category_aggregate_monthly_zip3` | `zip3` | `year_month` |
| 010 | `provider_procedure_category_aggregate_annual_zip3` | `zip3` | `year` |

## Usage

```sh
export DATABASE_URL="postgresql://user:pass@localhost:5432/dbname"
./scripts/export_views.sh            # writes to exports/
./scripts/export_views.sh my_dir     # writes to my_dir/
```
