### PR TITLE
++ Project statement modal

### DIFF
--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -3,6 +3,7 @@ import DetailPanel from "./DetailPanel/index";
 import Tooltip from "./Tooltip";
 import Legend from "./Legend";
 import ClickHint from "./ClickHint";
+import InfoModal from "./InfoModal";
 import { HEADER_HEIGHT, Z_INDEX } from "../../constants/layout";
 
 export default function Header() {
@@ -60,6 +61,7 @@ export default function Header() {
             <Tooltip />
             <DetailPanel />
             <ClickHint />
+            <InfoModal />
         </>
     );
 }

--- a/src/components/ui/InfoModal.tsx
+++ b/src/components/ui/InfoModal.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useCallback } from "react";
+import { Z_INDEX } from "../../constants/layout";
+import { INFO_MODAL_TITLE, INFO_MODAL_BODY, INFO_MODAL_NOTES } from "../../constants/infoModal";
+
+export default function InfoModal() {
+    const [visible, setVisible] = useState(true);
+
+    const close = useCallback(() => setVisible(false), []);
+
+    useEffect(() => {
+        if (!visible) return;
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [visible, close]);
+
+    if (!visible) return null;
+
+    return (
+        <div
+            onClick={close}
+            style={{
+                position: "fixed",
+                inset: 0,
+                zIndex: Z_INDEX.MODAL,
+                background: "rgba(26,25,23,0.55)",
+                backdropFilter: "blur(2px)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: 24,
+            }}
+        >
+            <div
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                    position: "relative",
+                    background: "var(--surface)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 6,
+                    boxShadow: "0 8px 40px rgba(0,0,0,0.18)",
+                    width: "100%",
+                    maxWidth: 580,
+                    maxHeight: "85vh",
+                    display: "flex",
+                    flexDirection: "column",
+                    overflow: "hidden",
+                }}
+            >
+                {/* Header */}
+                <div
+                    style={{
+                        padding: "24px 24px 18px",
+                        borderBottom: "1px solid var(--border)",
+                        flexShrink: 0,
+                    }}
+                >
+                    <p
+                        style={{
+                            fontSize: 9,
+                            fontWeight: 700,
+                            letterSpacing: "0.12em",
+                            textTransform: "uppercase",
+                            color: "var(--ink-dim)",
+                            marginBottom: 6,
+                        }}
+                    >
+                        About This Site
+                    </p>
+                    <h2
+                        style={{
+                            fontFamily: "var(--ff-sans)",
+                            fontSize: 20,
+                            fontWeight: 600,
+                            letterSpacing: "-0.02em",
+                            color: "var(--ink)",
+                            lineHeight: 1.25,
+                        }}
+                    >
+                        {INFO_MODAL_TITLE}
+                    </h2>
+
+                    <button
+                        onClick={close}
+                        aria-label="Close"
+                        style={{
+                            position: "absolute",
+                            top: 16,
+                            right: 16,
+                            width: 28,
+                            height: 28,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            background: "var(--surface2)",
+                            border: "1px solid var(--border)",
+                            borderRadius: "50%",
+                            cursor: "pointer",
+                            fontSize: 14,
+                            color: "var(--ink-mid)",
+                        }}
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                {/* Body */}
+                <div
+                    style={{
+                        flex: 1,
+                        overflowY: "auto",
+                        padding: "20px 24px 28px",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 20,
+                    }}
+                >
+                    <p
+                        style={{
+                            fontFamily: "var(--ff-serif)",
+                            fontSize: 14,
+                            lineHeight: 1.7,
+                            color: "var(--ink-mid)",
+                        }}
+                    >
+                        {INFO_MODAL_BODY}
+                    </p>
+
+                    {/* Important Notes */}
+                    <div>
+                        <p
+                            style={{
+                                fontSize: 10,
+                                fontWeight: 700,
+                                letterSpacing: "0.1em",
+                                textTransform: "uppercase",
+                                color: "var(--ink-dim)",
+                                marginBottom: 10,
+                            }}
+                        >
+                            Important Notes
+                        </p>
+                        <ul
+                            style={{
+                                listStyle: "none",
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 10,
+                            }}
+                        >
+                            {INFO_MODAL_NOTES.map((note, i) => (
+                                <li
+                                    key={i}
+                                    style={{
+                                        display: "flex",
+                                        gap: 10,
+                                        alignItems: "flex-start",
+                                    }}
+                                >
+                                    <span
+                                        style={{
+                                            flexShrink: 0,
+                                            marginTop: 5,
+                                            width: 5,
+                                            height: 5,
+                                            borderRadius: "50%",
+                                            background: "var(--accent)",
+                                        }}
+                                    />
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--ff-serif)",
+                                            fontSize: 13,
+                                            lineHeight: 1.65,
+                                            color: note.startsWith("[")
+                                                ? "var(--ink-dim)"
+                                                : "var(--ink-mid)",
+                                            fontStyle: note.startsWith("[") ? "italic" : "normal",
+                                        }}
+                                    >
+                                        {note}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                {/* Footer */}
+                <div
+                    style={{
+                        padding: "14px 24px",
+                        borderTop: "1px solid var(--border)",
+                        flexShrink: 0,
+                        display: "flex",
+                        justifyContent: "flex-end",
+                    }}
+                >
+                    <button
+                        onClick={close}
+                        style={{
+                            padding: "7px 20px",
+                            fontSize: 13,
+                            fontWeight: 600,
+                            fontFamily: "var(--ff-sans)",
+                            background: "var(--accent)",
+                            color: "#fff",
+                            border: "none",
+                            borderRadius: 3,
+                            cursor: "pointer",
+                            letterSpacing: "0.01em",
+                        }}
+                    >
+                        Get Started
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/infoModal.ts
+++ b/src/constants/infoModal.ts
@@ -1,0 +1,19 @@
+export const INFO_MODAL_TITLE = "Medicaid Dental Claim Data Visualization";
+
+export const INFO_MODAL_BODY =
+    "This site illustrates the 2018–2024 Medicaid dental claims data released by Health and Human " +
+    "Services (HHS) Open Data on February 8th, 2026. We used the National Plan and Provider " +
+    "Enumeration System (NPPES) to connect each claim to a zip-3, enabling a geographical view " +
+    "of the data. Medicaid dental coverage varies from state-to-state, with some states covering " +
+    "different populations and different procedures. This may account for some level of the " +
+    "perceived trends seen on this site. Our intention is to transform a massive dataset into " +
+    "digestible, actionable insights at the local, state, and national level. We hope this tool " +
+    "and the corresponding framework to organize the data can be useful for policymakers, " +
+    "providers, researchers, and all others interested in improving oral and systemic health.";
+
+export const INFO_MODAL_NOTES: string[] = [
+    "HHS Open Data does not include claims if there are less than 12 of a particular code per month, or if there are less than 12 unique beneficiaries per month. This may impact accuracy, especially in less populated areas.",
+    "We are displaying data at a zip-3 level to purposefully avoid identifying or targeting individual providers. This data is not intended to assist in finding outlier providers.",
+    "[Note about NPI changes/providers moving depending on how well we can address this]",
+    "[Explanation of what we did with mislabeled/incomplete data, US territories, etc]",
+];

--- a/src/constants/infoModal.ts
+++ b/src/constants/infoModal.ts
@@ -13,7 +13,7 @@ export const INFO_MODAL_BODY =
 
 export const INFO_MODAL_NOTES: string[] = [
     "HHS Open Data does not include claims if there are less than 12 of a particular code per month, or if there are less than 12 unique beneficiaries per month. This may impact accuracy, especially in less populated areas.",
-    "We are displaying data at a zip-3 level to purposefully avoid identifying or targeting individual providers. This data is not intended to assist in finding outlier providers.",
+    "We are displaying data at a ZIP3 level to purposefully avoid identifying or targeting individual providers. This data is not intended to assist in finding outlier providers.",
     "[Note about NPI changes/providers moving depending on how well we can address this]",
     "[Explanation of what we did with mislabeled/incomplete data, US territories, etc]",
 ];

--- a/src/constants/infoModal.ts
+++ b/src/constants/infoModal.ts
@@ -3,7 +3,7 @@ export const INFO_MODAL_TITLE = "Medicaid Dental Claim Data Visualization";
 export const INFO_MODAL_BODY =
     "This site illustrates the 2018–2024 Medicaid dental claims data released by Health and Human " +
     "Services (HHS) Open Data on February 8th, 2026. We used the National Plan and Provider " +
-    "Enumeration System (NPPES) to connect each claim to a zip-3, enabling a geographical view " +
+    "Enumeration System (NPPES) to connect each claim to a ZIP3, enabling a geographical view " +
     "of the data. Medicaid dental coverage varies from state-to-state, with some states covering " +
     "different populations and different procedures. This may account for some level of the " +
     "perceived trends seen on this site. Our intention is to transform a massive dataset into " +

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -5,6 +5,7 @@ export const Z_INDEX = {
     HEADER: 50,
     PANEL: 60,
     TOOLTIP: 200,
+    MODAL: 300,
 } as const;
 
 export const PANEL_TRANSITION = "0.3s cubic-bezier(0.22, 1, 0.36, 1)";


### PR DESCRIPTION
Close #10 
## Summary

Adds a project statement modal that displays automatically on page load, giving users context on the data source, methodology, and known limitations before interacting with the map.

- **New component** `InfoModal` — renders a centered, scrollable modal over a blurred backdrop. Closes on backdrop click, ✕ button, "Get Started" CTA, or `Escape` key. Self-contained local state (`useState(true)`), no store changes required.
- **New constants file** `src/constants/infoModal.ts` — separates all copy (`INFO_MODAL_TITLE`, `INFO_MODAL_BODY`, `INFO_MODAL_NOTES`) from the component, making it easy to update text without touching JSX.
- **`Z_INDEX.MODAL = 300`** added to `src/constants/layout.ts` to ensure the modal layers above the tooltip (`200`) and all other UI panels.
- `InfoModal` registered in `Header.tsx` alongside the existing UI panel components.

## Notes

Two placeholder notes in `INFO_MODAL_NOTES` are marked with `[...]` and styled italic/dimmed to indicate pending content:
- NPI changes / provider movement handling
- Treatment of mislabeled/incomplete data and US territories

These can be finalized and the placeholder syntax removed once the corresponding data decisions are documented.


## UI
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/93d2258d-49fe-4bcb-8c5c-179c2e4e0166" />

