### PR TITLE
docs(limitations): add cumulative data-loss summary table

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -12,6 +12,28 @@ This is a comprehensive list of limitations that affect the merged and geocoded 
 
 ---
 
+## Data-loss summary (HHS source → mapped dataset)
+
+Cumulative accounting of how many rows we lose at each stage of the pipeline, and the limit ID that explains each loss. "Rows in" of each stage equals "rows remaining" from the previous stage; numbers come from `data/MergedHHS-NPI/coverage_report.csv`, `geocode_failures.csv`, and the HHS source CSV.
+
+| # | Stage | Reason for exclusion | Rows in | Rows dropped | Rows remaining | Limit ID |
+|---|---|---|---:|---:|---:|---|
+| 0 | HHS source CSV | — (raw release, 7 columns, 2018-01 → 2024-12) | — | — | 227,083,361 | — |
+| 1 | Phase A filter ([`merge_hhs_nppes.py`](../scripts/merge_hhs_nppes.py)) | HCPCS code not D-prefixed (non-dental — medical, behavioral, etc.) | 227,083,361 | 203,014,787 | 24,068,574 | structural |
+| 2 | Phase B NPPES inner join | `SERVICING_PROVIDER_NPI_NUM` not found in same-month NPPES (all causes combined) | 24,068,574 | 895,691 (3.72%) | 23,172,883 | L07 |
+| 2a | ↳ sub-cause | Non-NPI servicing identifier (NULL, A-prefix Atypical, M-prefix Medicaid, sentinels, other malformed) | — | ~895,083 (~99.9% of drops) | — | L08 |
+| 2b | ↳ sub-cause | Real 10-digit NPI but registered after the NBER monthly snapshot (recoverable with ±1-month window) | — | 608 (~0.07% of drops) | — | L04 |
+| 3 | Geocoding (ArcGIS, collaborator handoff) | Address could not be geocoded (`geocode_status == 'U'`; 86 of 69,960 unique addresses) | 23,172,883 | 32,488 (0.14%) | 23,140,395 | L13 / L32 |
+| — | **Final mapped dataset** | — | — | — | **23,140,395** | — |
+
+**Cumulative loss from raw HHS:** 203,942,966 rows (89.81%) — almost entirely the non-dental filter at stage 1. From the dental-only universe of 24,068,574 rows, total downstream loss is 928,179 rows (3.86%).
+
+**Not counted here** (invisible upstream losses): HHS cell-suppression of small (provider × HCPCS × month) cells (L03), and claims-processing lag in 2024-11/2024-12 (L02). These never enter our row counts.
+
+**Sub-cause 2a is not yet broken out by bucket.** [`scripts/categorize_servicing_ids.py`](../scripts/categorize_servicing_ids.py) produces the exact NULL / A-prefix / M-prefix / sentinel / other split into `data/MergedHHS-NPI/servicing_id_categories.csv` — run it to fill in the row-level breakdown.
+
+---
+
 ## 1. Source-data limitations (inherent to HHS / NPPES / NBER releases)
 
 ### L01 🟥 Date range bounded by HHS release


### PR DESCRIPTION
## Summary

- Add a top-of-document table to `docs/LIMITATIONS.md` that walks row counts through every pipeline stage: raw HHS source -> non-dental filter -> NPPES inner join -> geocoding.
- Each row links the loss to the existing `L0X` limit IDs so reviewers don't have to cross-reference manually.
- Numbers are sourced from `data/MergedHHS-NPI/coverage_report.csv`, `geocode_failures.csv`, and the HHS source CSV (`wc -l = 227,083,362` incl. header).

## What the table shows

- Raw HHS: 227,083,361 rows -> dental-only: 24,068,574 (drops 203M non-dental, structural)
- NPPES inner join drops 895,691 (3.72%) -> 23,172,883 merged (L07); sub-split as ~895,083 non-NPI IDs (L08) + 608 adjacent-month-recoverable (L04)
- Geocoder: 86 of 69,960 unique addresses fail -> 32,488 claim rows lost (L13 / L32)
- Final mapped dataset: 23,140,395 rows

## What's not in the table

- Sub-cause 2a (NULL vs A-prefix vs M-prefix vs sentinel vs other malformed) isn't broken out — `scripts/categorize_servicing_ids.py` produces it on demand and the note in the doc points there.
- Upstream invisible losses (HHS cell-suppression L03, claims lag L02) are called out as not counted.

## Test plan

- [ ] Render `docs/LIMITATIONS.md` in GitHub's markdown preview and confirm the table renders cleanly with right-aligned numeric columns.
- [ ] Spot-check the math: 227,083,361 - 203,014,787 = 24,068,574; 24,068,574 - 895,691 = 23,172,883; 23,172,883 - 32,488 = 23,140,395.
- [ ] Confirm the `L0X` cross-references in the table all resolve to existing sections in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new data-loss summary documentation providing visibility into row-loss counts across all data processing pipeline stages, including detailed stage-by-stage exclusion tables, cumulative loss totals, and explanatory notes on upstream data adjustments impacting the final dataset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erovelli/medicaid-dent-policy/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->