### PR TITLE
fix(ci): prettier formatting + WCAG color contrast on Legend hint

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,11 +170,11 @@ This is the part most worth reading.
 
 Every state polygon and every ZIP3 polygon carries three feature-state fields:
 
-| Field      | Type    | Source       | Meaning                                      |
-| ---------- | ------- | ------------ | -------------------------------------------- |
+| Field      | Type    | Source       | Meaning                                                                                             |
+| ---------- | ------- | ------------ | --------------------------------------------------------------------------------------------------- |
 | `value`    | number  | Data JSON    | Active metric for the (year, category): total claims (volume) or claims-per-beneficiary (intensity) |
-| `hover`    | boolean | Mouse events | Cursor is over this polygon                  |
-| `selected` | boolean | Click events | Detail panel is open on this polygon         |
+| `hover`    | boolean | Mouse events | Cursor is over this polygon                                                                         |
+| `selected` | boolean | Click events | Detail panel is open on this polygon                                                                |
 
 The paint expression (`buildColorExpression` in [`src/lib/mapStyles.ts`](../src/lib/mapStyles.ts)) collapses these into a `fill-color`:
 
@@ -244,7 +244,7 @@ The store's single interesting piece of logic is in `setSelectedYear`, which cle
 Two elephants now: the deferred **monthly ZIP3 (58 MB)** and the new **monthly
 county (99 MB / 10.3 MB gzip)**, the largest artifact in the project. Both are
 loaded only on the first monthly-slider interaction, and `loadMonthlyData()`
-still fetches all three levels in one shot (so opening month view at *any* level
+still fetches all three levels in one shot (so opening month view at _any_ level
 pulls the county file too — a known cost). A post-MVP iteration (see
 [`docs/adr/0002-zip3-monthly-as-pmtiles.md`](adr/0002-zip3-monthly-as-pmtiles.md))
 should move the monthly grains to a vector-tile / range-requestable format and/or

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -16,15 +16,15 @@ This is a comprehensive list of limitations that affect the merged and geocoded 
 
 Cumulative accounting of how many rows we lose at each stage of the pipeline, and the limit ID that explains each loss. "Rows in" of each stage equals "rows remaining" from the previous stage; numbers come from `data/MergedHHS-NPI/coverage_report.csv`, `geocode_failures.csv`, and the HHS source CSV.
 
-| # | Stage | Reason for exclusion | Rows in | Rows dropped | Rows remaining | Limit ID |
-|---|---|---|---:|---:|---:|---|
-| 0 | HHS source CSV | — (raw release, 7 columns, 2018-01 → 2024-12) | — | — | 227,083,361 | — |
-| 1 | Phase A filter ([`merge_hhs_nppes.py`](../scripts/merge_hhs_nppes.py)) | HCPCS code not D-prefixed (non-dental — medical, behavioral, etc.) | 227,083,361 | 203,014,787 | 24,068,574 | structural |
-| 2 | Phase B NPPES inner join | `SERVICING_PROVIDER_NPI_NUM` not found in same-month NPPES (all causes combined) | 24,068,574 | 895,691 (3.72%) | 23,172,883 | L07 |
-| 2a | ↳ sub-cause | Non-NPI servicing identifier (NULL, A-prefix Atypical, M-prefix Medicaid, sentinels, other malformed) | — | ~895,083 (~99.9% of drops) | — | L08 |
-| 2b | ↳ sub-cause | Real 10-digit NPI but registered after the NBER monthly snapshot (recoverable with ±1-month window) | — | 608 (~0.07% of drops) | — | L04 |
-| 3 | Geocoding (ArcGIS, collaborator handoff) | Address could not be geocoded (`geocode_status == 'U'`; 86 of 69,960 unique addresses) | 23,172,883 | 32,488 (0.14%) | 23,140,395 | L13 / L32 |
-| — | **Final mapped dataset** | — | — | — | **23,140,395** | — |
+| #   | Stage                                                                  | Reason for exclusion                                                                                  |     Rows in |               Rows dropped | Rows remaining | Limit ID   |
+| --- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------: | -------------------------: | -------------: | ---------- |
+| 0   | HHS source CSV                                                         | — (raw release, 7 columns, 2018-01 → 2024-12)                                                         |           — |                          — |    227,083,361 | —          |
+| 1   | Phase A filter ([`merge_hhs_nppes.py`](../scripts/merge_hhs_nppes.py)) | HCPCS code not D-prefixed (non-dental — medical, behavioral, etc.)                                    | 227,083,361 |                203,014,787 |     24,068,574 | structural |
+| 2   | Phase B NPPES inner join                                               | `SERVICING_PROVIDER_NPI_NUM` not found in same-month NPPES (all causes combined)                      |  24,068,574 |            895,691 (3.72%) |     23,172,883 | L07        |
+| 2a  | ↳ sub-cause                                                            | Non-NPI servicing identifier (NULL, A-prefix Atypical, M-prefix Medicaid, sentinels, other malformed) |           — | ~895,083 (~99.9% of drops) |              — | L08        |
+| 2b  | ↳ sub-cause                                                            | Real 10-digit NPI but registered after the NBER monthly snapshot (recoverable with ±1-month window)   |           — |      608 (~0.07% of drops) |              — | L04        |
+| 3   | Geocoding (ArcGIS, collaborator handoff)                               | Address could not be geocoded (`geocode_status == 'U'`; 86 of 69,960 unique addresses)                |  23,172,883 |             32,488 (0.14%) |     23,140,395 | L13 / L32  |
+| —   | **Final mapped dataset**                                               | —                                                                                                     |           — |                          — | **23,140,395** | —          |
 
 **Cumulative loss from raw HHS:** 203,942,966 rows (89.81%) — almost entirely the non-dental filter at stage 1. From the dental-only universe of 24,068,574 rows, total downstream loss is 928,179 rows (3.86%).
 

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useCallback } from "react";
 import maplibregl from "maplibre-gl";
 import { Protocol } from "pmtiles";
 import { useMapStore } from "../../lib/store";
-import { fetchProtomapsStyle, buildColorExpression, colorExpression, quantileStops } from "../../lib/mapStyles";
+import {
+    fetchProtomapsStyle,
+    buildColorExpression,
+    colorExpression,
+    quantileStops,
+} from "../../lib/mapStyles";
 import type { LayerKey, GeoLevel, Metric, RegionDetail } from "../../lib/types";
 import {
     loadAnnualData,
@@ -340,7 +345,12 @@ export default function MapContainer() {
         const level = geoLevelRef.current;
         const data = getAnnualDataForLevel(level);
         const values = Object.values(data).map((recs) =>
-            getValueForRegion(recs, selectedYearRef.current, activeLayerRef.current, metricRef.current),
+            getValueForRegion(
+                recs,
+                selectedYearRef.current,
+                activeLayerRef.current,
+                metricRef.current,
+            ),
         );
         const stops = quantileStops(values, metricRef.current);
         stopsRef.current = stops;
@@ -434,7 +444,12 @@ export default function MapContainer() {
             map.current.setPaintProperty(
                 STATES_FILL,
                 "fill-color",
-                buildColorExpression(hoveredStateRef.current, postal, STATES_ID_PROP, stopsRef.current),
+                buildColorExpression(
+                    hoveredStateRef.current,
+                    postal,
+                    STATES_ID_PROP,
+                    stopsRef.current,
+                ),
             );
 
             const records = getStateAnnualData()[postal] ?? [];
@@ -470,7 +485,12 @@ export default function MapContainer() {
             map.current.setPaintProperty(
                 COUNTY_FILL,
                 "fill-color",
-                buildColorExpression(hoveredCountyRef.current, fips, COUNTY_ID_PROP, stopsRef.current),
+                buildColorExpression(
+                    hoveredCountyRef.current,
+                    fips,
+                    COUNTY_ID_PROP,
+                    stopsRef.current,
+                ),
             );
 
             const records = getCountyAnnualData()[fips] ?? [];
@@ -546,7 +566,12 @@ export default function MapContainer() {
             map.current.setPaintProperty(
                 STATES_FILL,
                 "fill-color",
-                buildColorExpression(postal, selectedStateRef.current, STATES_ID_PROP, stopsRef.current),
+                buildColorExpression(
+                    postal,
+                    selectedStateRef.current,
+                    STATES_ID_PROP,
+                    stopsRef.current,
+                ),
             );
 
             const val = getValueForRegion(
@@ -580,7 +605,12 @@ export default function MapContainer() {
             map.current.setPaintProperty(
                 COUNTY_FILL,
                 "fill-color",
-                buildColorExpression(fips, selectedCountyRef.current, COUNTY_ID_PROP, stopsRef.current),
+                buildColorExpression(
+                    fips,
+                    selectedCountyRef.current,
+                    COUNTY_ID_PROP,
+                    stopsRef.current,
+                ),
             );
 
             const val = getValueForRegion(

--- a/src/components/ui/Legend.tsx
+++ b/src/components/ui/Legend.tsx
@@ -69,7 +69,6 @@ export default function Legend() {
                     fontSize: 9,
                     color: "var(--ink-dim)",
                     marginTop: 8,
-                    opacity: 0.8,
                 }}
             >
                 Scale adjusts to the current view

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -103,7 +103,9 @@ export function getValueForRegion(
 ): number {
     if (!records) return 0;
     const rows = records.filter(
-        (r) => r.year === year && (activeLayer === "all" || CATEGORY_TO_KEY[r.category] === activeLayer),
+        (r) =>
+            r.year === year &&
+            (activeLayer === "all" || CATEGORY_TO_KEY[r.category] === activeLayer),
     );
     const claims = rows.reduce((sum, r) => sum + r.total_claims, 0);
     if (metric === "claims") return claims;


### PR DESCRIPTION
Fixes the two CI failures from PR #35.

- **prettier --check** flagged 4 files; ran `prettier --write` on each.
- **Lighthouse color-contrast** failed on the new "Scale adjusts to the current view" hint in Legend: `--ink-dim` on `--surface` is ~5:1 (passes WCAG), but the additional `opacity: 0.8` dropped the effective ratio to ~3.8:1 (fails 4.5:1). Removed the opacity; the text is still visually subdued thanks to `--ink-dim`.

Verified locally with Node 24:
- `npm run typecheck` ✓
- `npm test` ✓ (23/23)
- `npm run lint` ✓ (2 pre-existing warnings, 0 errors)
- `npm run format:check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with improved formatting for feature-state field descriptions.
  * Restructured limitations documentation with detailed breakdown of data-loss stages and causes.

* **Style**
  * Enhanced code readability through formatting improvements.
  * Removed unnecessary opacity styling from a UI component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/erovelli/medicaid-dent-policy/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->