### PR TITLE
feat(export): custom subset CSV download in Export modal

### DIFF
--- a/src/components/ui/ExportModal.tsx
+++ b/src/components/ui/ExportModal.tsx
@@ -11,12 +11,19 @@ import {
 } from "../../lib/export/synthesizeMap";
 import { LAYER_CONFIGS } from "../../constants/map";
 import type { GeoLevel } from "../../lib/types";
+import SubsetExportPanel from "./SubsetExportPanel";
 
 const LEVEL_LABEL: Record<GeoLevel, string> = {
     state: "State-level",
     county: "County-level",
     zip3: "ZIP3-level",
 };
+
+type ExportTab = "current" | "custom";
+const TABS: { key: ExportTab; label: string }[] = [
+    { key: "current", label: "Current view" },
+    { key: "custom", label: "Custom dataset" },
+];
 
 interface ExportModalProps {
     open: boolean;
@@ -45,6 +52,7 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
     const [previewError, setPreviewError] = useState<string | null>(null);
     const [exporting, setExporting] = useState<null | "png" | "jpeg" | "csv">(null);
     const previewSeqRef = useRef(0);
+    const [tab, setTab] = useState<ExportTab>("current");
 
     // Escape to close.
     useEffect(() => {
@@ -67,7 +75,7 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
     // Debounced preview regeneration. Sequence guards against a late finisher
     // from a prior set of filters overwriting the current preview.
     useEffect(() => {
-        if (!open) return;
+        if (!open || tab !== "current") return;
         setPreviewing(true);
         setPreviewError(null);
         const seq = ++previewSeqRef.current;
@@ -90,7 +98,7 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
             }
         }, PREVIEW_DEBOUNCE_MS);
         return () => window.clearTimeout(handle);
-    }, [open, activeLayer, selectedYear, metric, geoLevel]);
+    }, [open, tab, activeLayer, selectedYear, metric, geoLevel]);
 
     // The CSV "current view" inherits the user's monthly/annual selection, and
     // the geo level it's currently zoomed to. PNG/JPEG are state-only by spec.
@@ -248,88 +256,133 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
                         gap: 18,
                     }}
                 >
-                    {/* Preview thumbnail */}
+                    {/* Tab switcher: keeps the existing current-view export
+                        untouched under "Current view" and adds the subset
+                        builder under "Custom dataset". */}
                     <div
                         style={{
-                            border: "1px solid var(--border)",
-                            borderRadius: 4,
+                            display: "inline-flex",
+                            gap: 2,
+                            padding: 3,
                             background: "var(--surface2)",
-                            aspectRatio: "1600 / 1000",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            overflow: "hidden",
-                            position: "relative",
+                            border: "1px solid var(--border)",
+                            borderRadius: 6,
+                            alignSelf: "flex-start",
                         }}
                     >
-                        {previewUrl && (
-                            <img
-                                src={previewUrl}
-                                alt="Synthesized map preview"
-                                style={{
-                                    width: "100%",
-                                    height: "100%",
-                                    objectFit: "contain",
-                                    opacity: previewing ? 0.6 : 1,
-                                    transition: "opacity 0.2s",
-                                }}
-                            />
-                        )}
-                        {!previewUrl && !previewError && (
-                            <span
-                                style={{
-                                    fontFamily: "var(--ff-sans)",
-                                    fontSize: 12,
-                                    color: "var(--ink-dim)",
-                                }}
-                            >
-                                Generating preview…
-                            </span>
-                        )}
-                        {previewError && (
-                            <span
-                                style={{
-                                    fontFamily: "var(--ff-sans)",
-                                    fontSize: 12,
-                                    color: "var(--ink-dim)",
-                                    padding: "0 16px",
-                                    textAlign: "center",
-                                }}
-                            >
-                                Preview unavailable: {previewError}
-                            </span>
-                        )}
+                        {TABS.map((t) => {
+                            const active = t.key === tab;
+                            return (
+                                <button
+                                    key={t.key}
+                                    onClick={() => setTab(t.key)}
+                                    style={{
+                                        padding: "5px 14px",
+                                        fontSize: 12,
+                                        fontFamily: "var(--ff-sans)",
+                                        fontWeight: active ? 600 : 500,
+                                        color: active ? "var(--accent)" : "var(--ink-mid)",
+                                        background: active ? "var(--accent-light)" : "transparent",
+                                        border: "none",
+                                        borderRadius: 4,
+                                        cursor: "pointer",
+                                        transition: "background 0.12s, color 0.12s",
+                                    }}
+                                >
+                                    {t.label}
+                                </button>
+                            );
+                        })}
                     </div>
 
-                    <div
-                        style={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: 10,
-                        }}
-                    >
-                        <ExportButton
-                            label="PNG (transparent)"
-                            sub={`${LEVEL_LABEL[geoLevel]} choropleth · 1600×1000 · ${layerLabel}, ${selectedYear}`}
-                            onClick={() => handleExportImage("png")}
-                            disabled={exporting !== null}
-                            busy={exporting === "png"}
-                        />
-                        <ExportButton
-                            label="JPEG (white background)"
-                            sub={`Same as PNG with a white background, lighter weight for email/slides.`}
-                            onClick={() => handleExportImage("jpeg")}
-                            disabled={exporting !== null}
-                            busy={exporting === "jpeg"}
-                        />
-                        <ExportButton
-                            label="CSV"
-                            sub={`Per-region totals at this view · ${csvRowsHint}`}
-                            onClick={handleExportCsv}
-                            disabled={exporting !== null}
-                            busy={exporting === "csv"}
-                        />
-                    </div>
+                    {tab === "custom" && <SubsetExportPanel />}
+
+                    {tab === "current" && (
+                        <>
+                            {/* Preview thumbnail */}
+                            <div
+                                style={{
+                                    border: "1px solid var(--border)",
+                                    borderRadius: 4,
+                                    background: "var(--surface2)",
+                                    aspectRatio: "1600 / 1000",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    overflow: "hidden",
+                                    position: "relative",
+                                }}
+                            >
+                                {previewUrl && (
+                                    <img
+                                        src={previewUrl}
+                                        alt="Synthesized map preview"
+                                        style={{
+                                            width: "100%",
+                                            height: "100%",
+                                            objectFit: "contain",
+                                            opacity: previewing ? 0.6 : 1,
+                                            transition: "opacity 0.2s",
+                                        }}
+                                    />
+                                )}
+                                {!previewUrl && !previewError && (
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--ff-sans)",
+                                            fontSize: 12,
+                                            color: "var(--ink-dim)",
+                                        }}
+                                    >
+                                        Generating preview…
+                                    </span>
+                                )}
+                                {previewError && (
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--ff-sans)",
+                                            fontSize: 12,
+                                            color: "var(--ink-dim)",
+                                            padding: "0 16px",
+                                            textAlign: "center",
+                                        }}
+                                    >
+                                        Preview unavailable: {previewError}
+                                    </span>
+                                )}
+                            </div>
+
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: 10,
+                                }}
+                            >
+                                <ExportButton
+                                    label="PNG (transparent)"
+                                    sub={`${LEVEL_LABEL[geoLevel]} choropleth · 1600×1000 · ${layerLabel}, ${selectedYear}`}
+                                    onClick={() => handleExportImage("png")}
+                                    disabled={exporting !== null}
+                                    busy={exporting === "png"}
+                                />
+                                <ExportButton
+                                    label="JPEG (white background)"
+                                    sub={`Same as PNG with a white background, lighter weight for email/slides.`}
+                                    onClick={() => handleExportImage("jpeg")}
+                                    disabled={exporting !== null}
+                                    busy={exporting === "jpeg"}
+                                />
+                                <ExportButton
+                                    label="CSV"
+                                    sub={`Per-region totals at this view · ${csvRowsHint}`}
+                                    onClick={handleExportCsv}
+                                    disabled={exporting !== null}
+                                    busy={exporting === "csv"}
+                                />
+                            </div>
+                        </>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/components/ui/SubsetExportPanel.tsx
+++ b/src/components/ui/SubsetExportPanel.tsx
@@ -1,0 +1,652 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { GeoLevel, LayerKey } from "../../lib/types";
+import { useMapStore } from "../../lib/store";
+import {
+    getAnnualDataForLevel,
+    getMonthlyDataForLevel,
+    getEnrollmentForLevel,
+    getCountyNames,
+    loadMonthlyData,
+} from "../../lib/dataService";
+import { GEO_LEVELS, LAYER_ORDER, LAYER_CONFIGS } from "../../constants/map";
+import { STATE_USPS_TO_NAME } from "../../constants/stateFips";
+import { AVAILABLE_YEARS } from "../../constants/time";
+import { downloadCsv } from "../../lib/export/csv";
+import {
+    type Grain,
+    availableMonthlyPeriods,
+    buildSubsetCsvRows,
+    estimateSubsetRows,
+    rowsToSubsetCsv,
+    subsetCsvFilename,
+} from "../../lib/export/subsetCsv";
+
+const GRAINS: { key: Grain; label: string }[] = [
+    { key: "annual", label: "Annual" },
+    { key: "monthly", label: "Monthly" },
+];
+
+// Selectable category layers (every CDT division; "all" is offered separately
+// as the optional summed-total checkbox, not a row category).
+const CATEGORY_KEYS = LAYER_ORDER.filter((k) => k !== "all");
+
+// Above this many estimated rows the build can briefly jank the tab, so we
+// require an explicit override. County × every month × every category is the
+// realistic offender.
+const ROW_CAP = 250_000;
+
+// How many region rows to render at once; the rest stay selectable via search /
+// select-all without paying for thousands of DOM nodes.
+const REGION_DISPLAY_CAP = 250;
+
+function toggle<T>(set: Set<T>, value: T): Set<T> {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+}
+
+export default function SubsetExportPanel() {
+    const setMonthlyDataLoaded = useMapStore((s) => s.setMonthlyDataLoaded);
+
+    const [level, setLevel] = useState<GeoLevel>("state");
+    const [grain, setGrain] = useState<Grain>("annual");
+
+    const [selectedYears, setSelectedYears] = useState<Set<string>>(new Set(AVAILABLE_YEARS));
+    const [availableMonths, setAvailableMonths] = useState<string[]>([]);
+    const [selectedMonths, setSelectedMonths] = useState<Set<string>>(new Set());
+
+    const [selectedCategories, setSelectedCategories] = useState<Set<LayerKey>>(
+        new Set(CATEGORY_KEYS),
+    );
+    const [includeAllTotal, setIncludeAllTotal] = useState(false);
+
+    const [selectedRegions, setSelectedRegions] = useState<Set<string>>(new Set());
+    const [regionSearch, setRegionSearch] = useState("");
+    const [countyNames, setCountyNames] = useState<Record<string, string>>({});
+
+    const [monthlyLoading, setMonthlyLoading] = useState(false);
+    const [monthlyError, setMonthlyError] = useState<string | null>(null);
+    const [generating, setGenerating] = useState(false);
+    const [confirmLarge, setConfirmLarge] = useState(false);
+
+    // Region universe for the current level — keys of the always-loaded annual
+    // cache. (Monthly suppression can drop a few ids; the builder simply emits
+    // no rows for an id absent from the monthly cache.)
+    const regionUniverse = useMemo(() => {
+        return Object.keys(getAnnualDataForLevel(level)).sort();
+    }, [level]);
+
+    // Reset the region selection (default: all) whenever the level changes.
+    useEffect(() => {
+        setSelectedRegions(new Set(regionUniverse));
+        setRegionSearch("");
+    }, [regionUniverse]);
+
+    // County labels for the picker — lazy, memoized in dataService.
+    useEffect(() => {
+        if (level !== "county") return;
+        let cancelled = false;
+        getCountyNames()
+            .then((names) => {
+                if (!cancelled) setCountyNames(names);
+            })
+            .catch(() => {
+                /* fall back to raw GEOIDs */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [level]);
+
+    // Monthly grain needs the lazy ~16 MB monthly dataset. Load once, then
+    // default to every available month.
+    useEffect(() => {
+        if (grain !== "monthly") return;
+        let cancelled = false;
+        const ready = getMonthlyDataForLevel(level);
+        if (Object.keys(ready).length > 0) {
+            const months = availableMonthlyPeriods(ready);
+            setAvailableMonths(months);
+            setSelectedMonths((prev) => (prev.size ? prev : new Set(months)));
+            return;
+        }
+        setMonthlyLoading(true);
+        setMonthlyError(null);
+        loadMonthlyData()
+            .then(() => {
+                if (cancelled) return;
+                setMonthlyDataLoaded(true);
+                const months = availableMonthlyPeriods(getMonthlyDataForLevel(level));
+                setAvailableMonths(months);
+                setSelectedMonths(new Set(months));
+            })
+            .catch((err) => {
+                if (!cancelled) setMonthlyError(err instanceof Error ? err.message : String(err));
+            })
+            .finally(() => {
+                if (!cancelled) setMonthlyLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [grain, level, setMonthlyDataLoaded]);
+
+    const regionLabel = useCallback(
+        (id: string) => {
+            if (level === "state") return STATE_USPS_TO_NAME[id] ?? id;
+            if (level === "county") return countyNames[id] ?? id;
+            return `ZIP3 ${id}`;
+        },
+        [level, countyNames],
+    );
+
+    const filteredRegions = useMemo(() => {
+        const q = regionSearch.trim().toLowerCase();
+        if (!q) return regionUniverse;
+        return regionUniverse.filter(
+            (id) => id.toLowerCase().includes(q) || regionLabel(id).toLowerCase().includes(q),
+        );
+    }, [regionUniverse, regionSearch, regionLabel]);
+
+    const periodsSelected = grain === "annual" ? selectedYears : selectedMonths;
+    const estRows = estimateSubsetRows(
+        selectedRegions.size,
+        periodsSelected.size,
+        selectedCategories.size,
+        includeAllTotal,
+    );
+    const overCap = estRows > ROW_CAP;
+
+    const hasCategorySelection = selectedCategories.size > 0 || includeAllTotal;
+    const canDownload =
+        selectedRegions.size > 0 &&
+        periodsSelected.size > 0 &&
+        hasCategorySelection &&
+        !monthlyLoading &&
+        !generating &&
+        (!overCap || confirmLarge);
+
+    const handleDownload = useCallback(() => {
+        setGenerating(true);
+        // Defer one tick so the "Generating…" label paints before a large
+        // synchronous build blocks the thread.
+        setTimeout(() => {
+            try {
+                const periods = grain === "annual" ? [...selectedYears] : [...selectedMonths];
+                const rows = buildSubsetCsvRows({
+                    level,
+                    grain,
+                    periods,
+                    categories: [...selectedCategories],
+                    includeAllCategoriesTotal: includeAllTotal,
+                    regionIds: [...selectedRegions],
+                    annualData: grain === "annual" ? getAnnualDataForLevel(level) : undefined,
+                    monthlyData: grain === "monthly" ? getMonthlyDataForLevel(level) : undefined,
+                    enrollment: getEnrollmentForLevel(level),
+                    countyNames: level === "county" ? countyNames : undefined,
+                });
+                downloadCsv(subsetCsvFilename(level, grain, periods), rowsToSubsetCsv(rows));
+            } finally {
+                setGenerating(false);
+            }
+        }, 0);
+    }, [
+        grain,
+        level,
+        selectedYears,
+        selectedMonths,
+        selectedCategories,
+        includeAllTotal,
+        selectedRegions,
+        countyNames,
+    ]);
+
+    const shownRegions = filteredRegions.slice(0, REGION_DISPLAY_CAP);
+
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+            <p
+                style={{
+                    fontFamily: "var(--ff-sans)",
+                    fontSize: 12,
+                    color: "var(--ink-dim)",
+                    lineHeight: 1.45,
+                    margin: 0,
+                }}
+            >
+                Build a CSV of exactly the slice you need — one row per region × period × category.
+                Enrollee counts (ACS C27007) are per region-year, so they repeat across a region's
+                category rows.
+            </p>
+
+            {/* Geo level */}
+            <Section label="Geography">
+                <Segmented
+                    options={GEO_LEVELS}
+                    value={level}
+                    onChange={(k) => setLevel(k as GeoLevel)}
+                />
+            </Section>
+
+            {/* Time grain */}
+            <Section label="Time grain">
+                <Segmented options={GRAINS} value={grain} onChange={(k) => setGrain(k as Grain)} />
+            </Section>
+
+            {/* Periods */}
+            <Section
+                label={grain === "annual" ? "Years" : "Months"}
+                action={
+                    grain === "annual" ? (
+                        <SelectAllClear
+                            onAll={() => setSelectedYears(new Set(AVAILABLE_YEARS))}
+                            onClear={() => setSelectedYears(new Set())}
+                        />
+                    ) : availableMonths.length ? (
+                        <SelectAllClear
+                            onAll={() => setSelectedMonths(new Set(availableMonths))}
+                            onClear={() => setSelectedMonths(new Set())}
+                        />
+                    ) : null
+                }
+            >
+                {grain === "annual" ? (
+                    <ChipRow>
+                        {AVAILABLE_YEARS.map((y) => (
+                            <Chip
+                                key={y}
+                                label={y}
+                                active={selectedYears.has(y)}
+                                onClick={() => setSelectedYears((s) => toggle(s, y))}
+                            />
+                        ))}
+                    </ChipRow>
+                ) : monthlyLoading ? (
+                    <Hint>Loading monthly data (~16 MB)…</Hint>
+                ) : monthlyError ? (
+                    <Hint>Monthly data unavailable: {monthlyError}</Hint>
+                ) : (
+                    <ChipRow scroll>
+                        {availableMonths.map((m) => (
+                            <Chip
+                                key={m}
+                                label={m}
+                                active={selectedMonths.has(m)}
+                                onClick={() => setSelectedMonths((s) => toggle(s, m))}
+                            />
+                        ))}
+                    </ChipRow>
+                )}
+            </Section>
+
+            {/* Categories */}
+            <Section
+                label="Categories"
+                action={
+                    <SelectAllClear
+                        onAll={() => setSelectedCategories(new Set(CATEGORY_KEYS))}
+                        onClear={() => setSelectedCategories(new Set())}
+                    />
+                }
+            >
+                <ChipRow>
+                    {CATEGORY_KEYS.map((k) => (
+                        <Chip
+                            key={k}
+                            label={LAYER_CONFIGS[k].label}
+                            active={selectedCategories.has(k)}
+                            onClick={() => setSelectedCategories((s) => toggle(s, k))}
+                        />
+                    ))}
+                </ChipRow>
+                <label
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        marginTop: 10,
+                        fontFamily: "var(--ff-sans)",
+                        fontSize: 12,
+                        color: "var(--ink-mid)",
+                        cursor: "pointer",
+                    }}
+                >
+                    <input
+                        type="checkbox"
+                        checked={includeAllTotal}
+                        onChange={(e) => setIncludeAllTotal(e.target.checked)}
+                    />
+                    Also include an “All Categories” total row per region &amp; period
+                </label>
+            </Section>
+
+            {/* Regions */}
+            <Section
+                label="Regions"
+                action={
+                    <SelectAllClear
+                        onAll={() => setSelectedRegions(new Set(regionUniverse))}
+                        onClear={() => setSelectedRegions(new Set())}
+                    />
+                }
+            >
+                <input
+                    type="text"
+                    value={regionSearch}
+                    onChange={(e) => setRegionSearch(e.target.value)}
+                    placeholder="Search by name or code…"
+                    style={{
+                        width: "100%",
+                        padding: "7px 10px",
+                        fontSize: 12,
+                        fontFamily: "var(--ff-sans)",
+                        color: "var(--ink)",
+                        background: "var(--surface2)",
+                        border: "1px solid var(--border)",
+                        borderRadius: 4,
+                        marginBottom: 8,
+                        boxSizing: "border-box",
+                    }}
+                />
+                <p
+                    style={{
+                        fontFamily: "var(--ff-sans)",
+                        fontSize: 11,
+                        color: "var(--ink-dim)",
+                        margin: "0 0 8px",
+                    }}
+                >
+                    {selectedRegions.size} of {regionUniverse.length} selected
+                </p>
+                <div
+                    style={{
+                        maxHeight: 180,
+                        overflowY: "auto",
+                        border: "1px solid var(--border)",
+                        borderRadius: 4,
+                        padding: 6,
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 1,
+                    }}
+                >
+                    {shownRegions.map((id) => (
+                        <label
+                            key={id}
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 8,
+                                padding: "4px 6px",
+                                borderRadius: 3,
+                                fontFamily: "var(--ff-sans)",
+                                fontSize: 12,
+                                color: "var(--ink-mid)",
+                                cursor: "pointer",
+                            }}
+                        >
+                            <input
+                                type="checkbox"
+                                checked={selectedRegions.has(id)}
+                                onChange={() => setSelectedRegions((s) => toggle(s, id))}
+                            />
+                            <span style={{ color: "var(--ink)" }}>{regionLabel(id)}</span>
+                            {regionLabel(id) !== id && (
+                                <span style={{ color: "var(--ink-dim)" }}>{id}</span>
+                            )}
+                        </label>
+                    ))}
+                    {filteredRegions.length === 0 && (
+                        <Hint>No regions match “{regionSearch}”.</Hint>
+                    )}
+                    {filteredRegions.length > REGION_DISPLAY_CAP && (
+                        <Hint>
+                            +{filteredRegions.length - REGION_DISPLAY_CAP} more — refine your search
+                            to see them (select-all still covers every match).
+                        </Hint>
+                    )}
+                </div>
+            </Section>
+
+            {/* Footer: estimate + download */}
+            <div
+                style={{
+                    borderTop: "1px solid var(--border)",
+                    paddingTop: 14,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 10,
+                }}
+            >
+                <p
+                    style={{
+                        fontFamily: "var(--ff-sans)",
+                        fontSize: 12,
+                        color: overCap ? "var(--ink)" : "var(--ink-dim)",
+                        margin: 0,
+                    }}
+                >
+                    ~{estRows.toLocaleString()} rows
+                    {overCap && (
+                        <span style={{ color: "var(--ink)" }}>
+                            {" "}
+                            — that's a large file and may take a moment to build.
+                        </span>
+                    )}
+                </p>
+
+                {overCap && !confirmLarge ? (
+                    <button onClick={() => setConfirmLarge(true)} style={secondaryButtonStyle}>
+                        Generate anyway
+                    </button>
+                ) : (
+                    <button
+                        onClick={handleDownload}
+                        disabled={!canDownload}
+                        style={{
+                            ...primaryButtonStyle,
+                            opacity: canDownload ? 1 : 0.5,
+                            cursor: canDownload ? "pointer" : "default",
+                        }}
+                    >
+                        {generating ? "Generating…" : "Download CSV"}
+                    </button>
+                )}
+
+                {!hasCategorySelection && <Hint>Select at least one category.</Hint>}
+                {periodsSelected.size === 0 && grain === "annual" && (
+                    <Hint>Select at least one year.</Hint>
+                )}
+                {selectedRegions.size === 0 && <Hint>Select at least one region.</Hint>}
+            </div>
+        </div>
+    );
+}
+
+// ── Presentational helpers ────────────────────────────────────
+
+function Section({
+    label,
+    action,
+    children,
+}: {
+    label: string;
+    action?: React.ReactNode;
+    children: React.ReactNode;
+}) {
+    return (
+        <div>
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginBottom: 8,
+                }}
+            >
+                <span
+                    style={{
+                        fontSize: 9,
+                        fontWeight: 700,
+                        letterSpacing: "0.12em",
+                        textTransform: "uppercase",
+                        color: "var(--ink-dim)",
+                    }}
+                >
+                    {label}
+                </span>
+                {action}
+            </div>
+            {children}
+        </div>
+    );
+}
+
+function Segmented({
+    options,
+    value,
+    onChange,
+}: {
+    options: { key: string; label: string }[];
+    value: string;
+    onChange: (key: string) => void;
+}) {
+    return (
+        <div
+            style={{
+                display: "inline-flex",
+                gap: 2,
+                padding: 3,
+                background: "var(--surface2)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+            }}
+        >
+            {options.map(({ key, label }) => {
+                const active = key === value;
+                return (
+                    <button
+                        key={key}
+                        onClick={() => onChange(key)}
+                        style={{
+                            padding: "5px 14px",
+                            fontSize: 12,
+                            fontFamily: "var(--ff-sans)",
+                            fontWeight: active ? 600 : 500,
+                            color: active ? "var(--accent)" : "var(--ink-mid)",
+                            background: active ? "var(--accent-light)" : "transparent",
+                            border: "none",
+                            borderRadius: 4,
+                            cursor: "pointer",
+                            transition: "background 0.12s, color 0.12s",
+                        }}
+                    >
+                        {label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+function ChipRow({ children, scroll }: { children: React.ReactNode; scroll?: boolean }) {
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 6,
+                ...(scroll ? { maxHeight: 132, overflowY: "auto" } : null),
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+    return (
+        <button
+            onClick={onClick}
+            style={{
+                padding: "5px 11px",
+                fontSize: 12,
+                fontFamily: "var(--ff-sans)",
+                fontWeight: active ? 600 : 500,
+                color: active ? "var(--accent)" : "var(--ink-mid)",
+                background: active ? "var(--accent-light)" : "var(--surface2)",
+                border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 4,
+                cursor: "pointer",
+                transition: "background 0.12s, color 0.12s, border-color 0.12s",
+            }}
+        >
+            {label}
+        </button>
+    );
+}
+
+function SelectAllClear({ onAll, onClear }: { onAll: () => void; onClear: () => void }) {
+    const linkStyle: React.CSSProperties = {
+        background: "none",
+        border: "none",
+        padding: 0,
+        fontFamily: "var(--ff-sans)",
+        fontSize: 11,
+        fontWeight: 600,
+        color: "var(--accent)",
+        cursor: "pointer",
+    };
+    return (
+        <span style={{ display: "flex", gap: 10 }}>
+            <button onClick={onAll} style={linkStyle}>
+                All
+            </button>
+            <button onClick={onClear} style={linkStyle}>
+                Clear
+            </button>
+        </span>
+    );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+    return (
+        <p
+            style={{
+                fontFamily: "var(--ff-sans)",
+                fontSize: 11,
+                color: "var(--ink-dim)",
+                margin: "4px 2px 0",
+                lineHeight: 1.4,
+            }}
+        >
+            {children}
+        </p>
+    );
+}
+
+const primaryButtonStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "11px 14px",
+    background: "var(--accent)",
+    color: "#fff",
+    border: "none",
+    borderRadius: 4,
+    fontFamily: "var(--ff-sans)",
+    fontSize: 13,
+    fontWeight: 600,
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "11px 14px",
+    background: "var(--surface2)",
+    color: "var(--ink)",
+    border: "1px solid var(--accent)",
+    borderRadius: 4,
+    fontFamily: "var(--ff-sans)",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+};

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -6,7 +6,7 @@ import type {
     MonthlyDataRecord,
     EnrollmentRecord,
 } from "./types";
-import { CATEGORY_TO_KEY, DATA_PATHS } from "../constants/map";
+import { CATEGORY_TO_KEY, COUNTY_GEOJSON, DATA_PATHS } from "../constants/map";
 
 // ── Module-level caches ───────────────────────────────────────
 let stateAnnualCache: Record<string, DataRecord[]> = {};
@@ -162,6 +162,40 @@ export function getEnrolleesFor(level: GeoLevel, id: string, year: string): numb
     if (!recs) return null;
     const hit = recs.find((r) => r.year === year);
     return hit ? hit.medicaid_enrollees : null;
+}
+
+// ── County name lookup (subset-export region picker) ──────────
+// counties.geojson (the map's county source) carries a human-readable `name`
+// property ("Autauga County, AL") keyed by 5-digit GEOID. The custom-subset
+// region picker needs those labels. Parse once and memoize; the fetch hits the
+// browser cache after the map's initial county load, so it's effectively free.
+let countyNamesCache: Record<string, string> | null = null;
+let countyNamesPromise: Promise<Record<string, string>> | null = null;
+
+export async function getCountyNames(): Promise<Record<string, string>> {
+    if (countyNamesCache) return countyNamesCache;
+    if (countyNamesPromise) return countyNamesPromise;
+    const BASE = import.meta.env.BASE_URL;
+    countyNamesPromise = (async () => {
+        const res = await fetch(`${BASE}${COUNTY_GEOJSON}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const geo = (await res.json()) as {
+            features?: Array<{ id?: string; properties?: { GEOID?: string; name?: string } }>;
+        };
+        const names: Record<string, string> = {};
+        for (const f of geo.features ?? []) {
+            const id = f.properties?.GEOID ?? f.id;
+            const name = f.properties?.name;
+            if (id && name) names[id] = name;
+        }
+        countyNamesCache = names;
+        return names;
+    })().catch((err) => {
+        // Allow a later retry rather than caching the rejection forever.
+        countyNamesPromise = null;
+        throw err;
+    });
+    return countyNamesPromise;
 }
 
 // ── Value computation ─────────────────────────────────────────

--- a/src/lib/export/subsetCsv.test.ts
+++ b/src/lib/export/subsetCsv.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import type { DataRecord, MonthlyDataRecord, EnrollmentRecord } from "../types";
+import {
+    SUBSET_CSV_COLUMNS,
+    buildSubsetCsvRows,
+    rowsToSubsetCsv,
+    availableMonthlyPeriods,
+    estimateSubsetRows,
+    subsetCsvFilename,
+} from "./subsetCsv";
+
+const annual: Record<string, DataRecord[]> = {
+    CA: [
+        {
+            year: "2024",
+            category: "Preventive",
+            total_claims: 100,
+            total_beneficiaries_served: 80,
+            total_amount_paid: 5000,
+        },
+        {
+            year: "2024",
+            category: "Restorative",
+            total_claims: 50,
+            total_beneficiaries_served: 40,
+            total_amount_paid: 7500,
+        },
+        {
+            year: "2023",
+            category: "Preventive",
+            total_claims: 200,
+            total_beneficiaries_served: 150,
+            total_amount_paid: 9000,
+        },
+    ],
+    AL: [
+        {
+            year: "2024",
+            category: "Preventive",
+            total_claims: 10,
+            total_beneficiaries_served: 9,
+            total_amount_paid: 600,
+        },
+    ],
+    DC: [
+        {
+            year: "2024",
+            category: "Restorative",
+            total_claims: 0,
+            total_beneficiaries_served: 0,
+            total_amount_paid: 0,
+        },
+    ],
+};
+
+const enrollment: Record<string, EnrollmentRecord[]> = {
+    CA: [
+        { year: "2024", medicaid_enrollees: 1000 },
+        { year: "2023", medicaid_enrollees: 800 },
+    ],
+    // AL intentionally has no enrollment record → enrollee/rate columns blank.
+};
+
+describe("SUBSET_CSV_COLUMNS", () => {
+    it("has the documented columns in the documented order", () => {
+        expect([...SUBSET_CSV_COLUMNS]).toEqual([
+            "region_id",
+            "region_name",
+            "level",
+            "period",
+            "category",
+            "total_claims",
+            "total_beneficiaries_served",
+            "total_amount_paid",
+            "medicaid_enrollees",
+            "claims_per_enrollee",
+        ]);
+    });
+
+    it("rowsToSubsetCsv emits the header row in order", () => {
+        const csv = rowsToSubsetCsv([]);
+        expect(csv.split("\n")[0]).toBe(
+            "region_id,region_name,level,period,category,total_claims,total_beneficiaries_served,total_amount_paid,medicaid_enrollees,claims_per_enrollee",
+        );
+    });
+});
+
+describe("buildSubsetCsvRows — annual", () => {
+    it("expands across multiple periods × categories", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2023", "2024"],
+            categories: ["preventive", "restorative"],
+            regionIds: ["CA", "AL"],
+            annualData: annual,
+            enrollment,
+        });
+        // CA: 2023 Preventive (Restorative absent), 2024 Preventive, 2024 Restorative = 3
+        // AL: 2024 Preventive = 1
+        expect(rows).toHaveLength(4);
+        const caRows = rows.filter((r) => r.region_id === "CA");
+        expect(caRows.map((r) => `${r.period}/${r.category}`)).toEqual([
+            "2023/Preventive",
+            "2024/Preventive",
+            "2024/Restorative",
+        ]);
+    });
+
+    it("joins enrollees and computes claims_per_enrollee", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            regionIds: ["CA"],
+            annualData: annual,
+            enrollment,
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].medicaid_enrollees).toBe(1000);
+        // 100 claims / 1000 enrollees
+        expect(rows[0].claims_per_enrollee).toBe(0.1);
+    });
+
+    it("blanks enrollee + rate columns when no denominator exists", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            regionIds: ["AL"],
+            annualData: annual,
+            enrollment,
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].medicaid_enrollees).toBe("");
+        expect(rows[0].claims_per_enrollee).toBe("");
+    });
+
+    it("drops category rows whose totals are all zero", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["restorative"],
+            regionIds: ["DC"],
+            annualData: annual,
+            enrollment,
+        });
+        expect(rows).toHaveLength(0);
+    });
+
+    it("filters to the explicitly requested regions", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            regionIds: ["CA"],
+            annualData: annual,
+            enrollment,
+        });
+        expect(rows.every((r) => r.region_id === "CA")).toBe(true);
+    });
+
+    it("adds a summed All Categories row when requested", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            includeAllCategoriesTotal: true,
+            regionIds: ["CA"],
+            annualData: annual,
+            enrollment,
+        });
+        const all = rows.find((r) => r.category === "All Categories");
+        expect(all).toBeDefined();
+        // 100 (Preventive) + 50 (Restorative) summed across every category present
+        expect(all?.total_claims).toBe(150);
+        expect(all?.total_amount_paid).toBe(12500);
+        // rate uses the summed claims over the same denominator
+        expect(all?.claims_per_enrollee).toBe(0.15);
+    });
+
+    it("resolves state region_name via the postal lookup", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            regionIds: ["CA", "AL"],
+            annualData: annual,
+            enrollment,
+        });
+        expect(rows.find((r) => r.region_id === "CA")?.region_name).toBe("California");
+        expect(rows.find((r) => r.region_id === "AL")?.region_name).toBe("Alabama");
+    });
+
+    it("uses countyNames for county-level region_name", () => {
+        const countyData: Record<string, DataRecord[]> = {
+            "01001": [
+                {
+                    year: "2024",
+                    category: "Preventive",
+                    total_claims: 5,
+                    total_beneficiaries_served: 4,
+                    total_amount_paid: 300,
+                },
+            ],
+        };
+        const rows = buildSubsetCsvRows({
+            level: "county",
+            grain: "annual",
+            periods: ["2024"],
+            categories: ["preventive"],
+            regionIds: ["01001"],
+            annualData: countyData,
+            countyNames: { "01001": "Autauga County, AL" },
+        });
+        expect(rows[0].region_name).toBe("Autauga County, AL");
+        // and the comma'd name survives CSV round-trip (auto-quoted by Papa)
+        const csv = rowsToSubsetCsv(rows);
+        expect(csv).toContain('"Autauga County, AL"');
+    });
+
+    it("sorts by region_id, then period, then category", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "annual",
+            periods: ["2024", "2023"],
+            categories: ["restorative", "preventive"],
+            regionIds: ["CA", "AL"],
+            annualData: annual,
+            enrollment,
+        });
+        const keys = rows.map((r) => `${r.region_id}|${r.period}|${r.category}`);
+        expect(keys).toEqual([...keys].sort());
+    });
+});
+
+describe("buildSubsetCsvRows — monthly", () => {
+    const monthly: Record<string, MonthlyDataRecord[]> = {
+        CA: [
+            {
+                year_month: "2024-06",
+                category: "Preventive",
+                total_claims: 12,
+                total_beneficiaries_served: 10,
+                total_amount_paid: 500,
+            },
+            {
+                year_month: "2024-07",
+                category: "Preventive",
+                total_claims: 15,
+                total_beneficiaries_served: 12,
+                total_amount_paid: 600,
+            },
+        ],
+    };
+
+    it("filters by year_month and uses the endpoint-year enrollment", () => {
+        const rows = buildSubsetCsvRows({
+            level: "state",
+            grain: "monthly",
+            periods: ["2024-06"],
+            categories: ["preventive"],
+            regionIds: ["CA"],
+            monthlyData: monthly,
+            enrollment,
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].period).toBe("2024-06");
+        expect(rows[0].total_claims).toBe(12);
+        // 2024 endpoint-year enrollment reused for the month
+        expect(rows[0].medicaid_enrollees).toBe(1000);
+        expect(rows[0].claims_per_enrollee).toBe(0.012);
+    });
+
+    it("availableMonthlyPeriods returns sorted distinct year-months", () => {
+        expect(availableMonthlyPeriods(monthly)).toEqual(["2024-06", "2024-07"]);
+    });
+});
+
+describe("estimateSubsetRows", () => {
+    it("multiplies dimensions and counts the all-categories row", () => {
+        expect(estimateSubsetRows(3, 5, 2, false)).toBe(30);
+        expect(estimateSubsetRows(3, 5, 2, true)).toBe(45);
+    });
+});
+
+describe("subsetCsvFilename", () => {
+    it("encodes level, grain, and the period span", () => {
+        expect(subsetCsvFilename("state", "annual", ["2020", "2024", "2022"])).toBe(
+            "medicaid-dental_subset_state_annual_2020_2024.csv",
+        );
+        expect(subsetCsvFilename("zip3", "monthly", ["2024-06"])).toBe(
+            "medicaid-dental_subset_zip3_monthly_2024-06.csv",
+        );
+    });
+});

--- a/src/lib/export/subsetCsv.ts
+++ b/src/lib/export/subsetCsv.ts
@@ -1,0 +1,250 @@
+import Papa from "papaparse";
+import type { DataRecord, MonthlyDataRecord, EnrollmentRecord, GeoLevel, LayerKey } from "../types";
+import { CATEGORY_TO_KEY, LAYER_CONFIGS } from "../../constants/map";
+import { STATE_USPS_TO_NAME } from "../../constants/stateFips";
+
+// The custom-subset export is a *separate* schema from the current-view CSV in
+// csv.ts: it is tidy/long (one row per region × period × category, across many
+// of each in a single file) and carries the ACS Medicaid-enrollee denominator
+// plus a derived claims-per-enrollee rate. csv.ts is left untouched so its
+// pinned column contract (and tests) don't move.
+export const SUBSET_CSV_COLUMNS = [
+    "region_id",
+    "region_name",
+    "level",
+    "period",
+    "category",
+    "total_claims",
+    "total_beneficiaries_served",
+    "total_amount_paid",
+    "medicaid_enrollees",
+    "claims_per_enrollee",
+] as const;
+
+export type SubsetCsvColumn = (typeof SUBSET_CSV_COLUMNS)[number];
+export type SubsetCsvRow = Record<SubsetCsvColumn, string | number>;
+
+export type Grain = "annual" | "monthly";
+
+// Pseudo-category label for the optional summed-across-all-categories row.
+// Matches the live map / csv.ts "All Categories" wording.
+export const ALL_CATEGORIES_LABEL = "All Categories";
+
+interface BuildSubsetRowsArgs {
+    level: GeoLevel;
+    grain: Grain;
+    // Years (annual) or year-months (monthly) to emit.
+    periods: string[];
+    // Specific category layer keys to emit one row each for. "all" must not
+    // appear here — use includeAllCategoriesTotal for the summed row instead.
+    categories: LayerKey[];
+    // When true, add one summed "All Categories" row per region × period.
+    includeAllCategoriesTotal?: boolean;
+    // Explicit region ids (postal / FIPS GEOID / 3-digit ZIP3) to include.
+    regionIds: string[];
+    // Annual or monthly claims cache, keyed by region id — supply the one that
+    // matches `grain`.
+    annualData?: Record<string, DataRecord[]>;
+    monthlyData?: Record<string, MonthlyDataRecord[]>;
+    // ACS C27007 enrollment cache for `level`, keyed by region id. Optional —
+    // a missing cache simply blanks the enrollee/rate columns.
+    enrollment?: Record<string, EnrollmentRecord[]>;
+    // GEOID → "County, ST" labels (only consulted at county level).
+    countyNames?: Record<string, string>;
+}
+
+interface CategoryTotals {
+    claims: number;
+    beneficiaries: number;
+    amountPaid: number;
+}
+
+function emptyTotals(): CategoryTotals {
+    return { claims: 0, beneficiaries: 0, amountPaid: 0 };
+}
+
+function regionName(level: GeoLevel, id: string, countyNames?: Record<string, string>): string {
+    if (level === "state") return STATE_USPS_TO_NAME[id] ?? id;
+    if (level === "county") return countyNames?.[id] ?? id;
+    return `ZIP3 ${id}`;
+}
+
+// ACS is annual; monthly rows reuse the endpoint-year enrollment (same
+// convention as getValueForRegionMonthly). Returns null when the geography has
+// no enrollment record for that year — callers blank the columns rather than
+// emit a misleading 0.
+function enrolleesFor(
+    enrollment: Record<string, EnrollmentRecord[]> | undefined,
+    id: string,
+    year: string,
+): number | null {
+    const recs = enrollment?.[id];
+    if (!recs) return null;
+    const hit = recs.find((r) => r.year === year);
+    return hit ? hit.medicaid_enrollees : null;
+}
+
+// Rate is claims / enrollees, rounded for a tidy CSV; blank when the
+// denominator is missing or non-positive so "no denominator" reads differently
+// from a true 0 rate.
+function rateCell(claims: number, enrollees: number | null): string | number {
+    if (enrollees == null || enrollees <= 0) return "";
+    return Number((claims / enrollees).toFixed(6));
+}
+
+function periodYear(grain: Grain, period: string): string {
+    return grain === "annual" ? period : period.slice(0, 4);
+}
+
+function isZero(t: CategoryTotals): boolean {
+    return t.claims === 0 && t.beneficiaries === 0 && t.amountPaid === 0;
+}
+
+/**
+ * Expand the user's selection into tidy/long rows. One pass per region; for
+ * each selected period we bucket that region's records by category in a single
+ * sweep, so the cost is O(records) rather than O(records × categories).
+ */
+export function buildSubsetCsvRows({
+    level,
+    grain,
+    periods,
+    categories,
+    includeAllCategoriesTotal = false,
+    regionIds,
+    annualData,
+    monthlyData,
+    enrollment,
+    countyNames,
+}: BuildSubsetRowsArgs): SubsetCsvRow[] {
+    const data: Record<string, Array<DataRecord | MonthlyDataRecord>> = grain === "monthly"
+        ? (monthlyData ?? {})
+        : (annualData ?? {});
+    const periodOf = (r: DataRecord | MonthlyDataRecord): string =>
+        grain === "monthly" ? (r as MonthlyDataRecord).year_month : (r as DataRecord).year;
+
+    const wantedCategories = new Set<LayerKey>(categories);
+    const rows: SubsetCsvRow[] = [];
+
+    for (const id of regionIds) {
+        const records = data[id];
+        if (!records) continue;
+        const name = regionName(level, id, countyNames);
+
+        for (const period of periods) {
+            // Bucket this region/period's records once: per selected category +
+            // an "all" accumulator for the optional summed row.
+            const perCategory = new Map<LayerKey, CategoryTotals>();
+            const allTotals = emptyTotals();
+            let sawAny = false;
+
+            for (const r of records) {
+                if (periodOf(r) !== period) continue;
+                sawAny = true;
+                if (includeAllCategoriesTotal) {
+                    allTotals.claims += r.total_claims;
+                    allTotals.beneficiaries += r.total_beneficiaries_served;
+                    allTotals.amountPaid += r.total_amount_paid;
+                }
+                const key = CATEGORY_TO_KEY[r.category];
+                if (!key || !wantedCategories.has(key)) continue;
+                let bucket = perCategory.get(key);
+                if (!bucket) {
+                    bucket = emptyTotals();
+                    perCategory.set(key, bucket);
+                }
+                bucket.claims += r.total_claims;
+                bucket.beneficiaries += r.total_beneficiaries_served;
+                bucket.amountPaid += r.total_amount_paid;
+            }
+
+            if (!sawAny) continue;
+
+            const year = periodYear(grain, period);
+            const enrollees = enrolleesFor(enrollment, id, year);
+            const enrolleesCell: string | number = enrollees == null ? "" : enrollees;
+
+            for (const cat of categories) {
+                const totals = perCategory.get(cat);
+                if (!totals || isZero(totals)) continue;
+                rows.push({
+                    region_id: id,
+                    region_name: name,
+                    level,
+                    period,
+                    category: LAYER_CONFIGS[cat].label,
+                    total_claims: totals.claims,
+                    total_beneficiaries_served: totals.beneficiaries,
+                    total_amount_paid: totals.amountPaid,
+                    medicaid_enrollees: enrolleesCell,
+                    claims_per_enrollee: rateCell(totals.claims, enrollees),
+                });
+            }
+
+            if (includeAllCategoriesTotal && !isZero(allTotals)) {
+                rows.push({
+                    region_id: id,
+                    region_name: name,
+                    level,
+                    period,
+                    category: ALL_CATEGORIES_LABEL,
+                    total_claims: allTotals.claims,
+                    total_beneficiaries_served: allTotals.beneficiaries,
+                    total_amount_paid: allTotals.amountPaid,
+                    medicaid_enrollees: enrolleesCell,
+                    claims_per_enrollee: rateCell(allTotals.claims, enrollees),
+                });
+            }
+        }
+    }
+
+    // Deterministic, diffable order: region, then period, then category label.
+    rows.sort(
+        (a, b) =>
+            String(a.region_id).localeCompare(String(b.region_id)) ||
+            String(a.period).localeCompare(String(b.period)) ||
+            String(a.category).localeCompare(String(b.category)),
+    );
+    return rows;
+}
+
+/** Distinct year-months present in the monthly cache, sorted ascending. */
+export function availableMonthlyPeriods(
+    monthlyData: Record<string, MonthlyDataRecord[]>,
+): string[] {
+    const set = new Set<string>();
+    for (const records of Object.values(monthlyData)) {
+        for (const r of records) set.add(r.year_month);
+    }
+    return [...set].sort();
+}
+
+/** Estimate row count for the UI guardrail (before zero-row dropping). */
+export function estimateSubsetRows(
+    regionCount: number,
+    periodCount: number,
+    categoryCount: number,
+    includeAllCategoriesTotal: boolean,
+): number {
+    return regionCount * periodCount * (categoryCount + (includeAllCategoriesTotal ? 1 : 0));
+}
+
+export function subsetCsvFilename(level: GeoLevel, grain: Grain, periods: string[]): string {
+    const sorted = [...periods].sort();
+    const span =
+        sorted.length === 0
+            ? "all"
+            : sorted.length === 1
+              ? sorted[0]
+              : `${sorted[0]}_${sorted[sorted.length - 1]}`;
+    return `medicaid-dental_subset_${level}_${grain}_${span}.csv`;
+}
+
+export function rowsToSubsetCsv(rows: SubsetCsvRow[]): string {
+    // Papa auto-quotes fields containing the delimiter (county names like
+    // "Autauga County, AL"), so quotes:false is safe here.
+    return Papa.unparse(
+        { fields: [...SUBSET_CSV_COLUMNS], data: rows },
+        { quotes: false, newline: "\n" },
+    );
+}


### PR DESCRIPTION
## What

Adds a second **Custom dataset** tab to the Export modal that lets a user download an arbitrary slice of the data as one CSV — modeled on the [Medicaid.gov Scorecard](https://www.medicaid.gov/state-overviews/scorecard) download pattern. Pick a **geo level**, **time grain** (annual/monthly), one-or-more **periods**, **categories**, and **specific regions** (searchable multi-select), then download exactly that slice.

The existing **Current view** PNG/JPEG/CSV export is untouched — this is purely additive.

## Why

Today's export only saves *the current map view* (one level x one period x one category). A researcher who wants e.g. "preventive + restorative claims for TX, CA, FL across 2020-2024" had to flip the map controls and export repeatedly. This builds the file in one shot.

## How

Entirely **client-side** — built from the in-memory NDJSON caches that already back the map, so **no hosting changes and no new dependencies** (Papa Parse already ships with the current-view CSV).

Output is tidy/long (one row per region x period x category) and joins the ACS C27007 Medicaid-enrollee denominator plus a derived claims-per-enrollee rate:

```
region_id, region_name, level, period, category,
total_claims, total_beneficiaries_served, total_amount_paid,
medicaid_enrollees, claims_per_enrollee
```

### Files
- **`src/lib/export/subsetCsv.ts`** (new) — pure builder (`buildSubsetCsvRows`, `rowsToSubsetCsv`, `availableMonthlyPeriods`, `estimateSubsetRows`, `subsetCsvFilename`). Its own column schema, so `csv.ts`'s pinned contract and tests don't move.
- **`src/lib/export/subsetCsv.test.ts`** (new) — 15 unit tests (schema, multi-period x multi-category expansion, enrollee join + rate incl. blank-when-no-denominator, drop-all-zero, region filter, deterministic sort, monthly grain).
- **`src/components/ui/SubsetExportPanel.tsx`** (new) — the tab UI: segmented level/grain, period & category chips, searchable region multi-select, live row-count estimate with a >250k-row guardrail.
- **`src/lib/dataService.ts`** — memoized `getCountyNames()` (parses `counties.geojson` for picker labels).
- **`src/components/ui/ExportModal.tsx`** — 2-tab switcher; off-screen preview render gated to the current-view tab.

Monthly grain reuses the existing one-time lazy `loadMonthlyData()` (~16 MB), shown behind a loading state.

## Verification
- `npm run typecheck` clean; `npm run lint` adds no new warnings; **48/48** unit tests pass; `npm run build` succeeds (new code lands in the lazy `ExportModal` chunk).
- Live dev smoke: tab switcher, annual download (captured CSV — correct header, correct enrollee join + rate e.g. CA/Preventive/2024 = 0.939671, region->period->category sort, all-zero rows dropped), monthly lazy-load (month chips + estimate update), and county-name labels ("Autauga County, AL", 2,667-county universe) all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom export functionality with filtering options—users can now download subset CSV files filtered by geography level, time grain (annual/monthly), periods, categories, and regions, alongside the existing current-view export option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->