### PR TITLE
feat(ui): mobile-responsive layout with drag-resizable bottom sheets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
         <meta
             name="description"
             content="Interactive choropleth map of U.S. Medicaid dental service utilization from 2018–2024, showing state and ZIP3-level trends by procedure category."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ export default function App() {
     useUrlSync();
 
     return (
-        <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
+        <div className="app-shell" style={{ position: "relative", width: "100%" }}>
             <Header />
             <div
                 style={{

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -22,11 +22,13 @@ import {
     getEnrolleesFor,
 } from "../../lib/dataService";
 import type { DataRecord, MonthlyDataRecord } from "../../lib/types";
+import { MOBILE_MEDIA_QUERY, COARSE_POINTER_QUERY } from "../../constants/layout";
 import {
     MAP_CENTER,
     MAP_ZOOM,
     MAP_MIN_ZOOM,
     MAP_MAX_ZOOM,
+    CONUS_BOUNDS,
     STATES_SOURCE,
     STATES_FILL,
     STATES_STROKE,
@@ -1060,24 +1062,41 @@ export default function MapContainer() {
 
             if (!mapContainer.current) return;
 
+            // Init-time only (no resize handling): the viewport class rarely
+            // changes mid-session, and re-fitting under the user would fight
+            // their pan/zoom.
+            const smallViewport = window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+            const coarsePointer = window.matchMedia(COARSE_POINTER_QUERY).matches;
+
             map.current = new maplibregl.Map({
                 container: mapContainer.current,
                 style,
-                center: MAP_CENTER,
-                zoom: MAP_ZOOM,
+                // The fixed center/zoom crop both seaboards on a portrait
+                // phone — fit the continental US to the actual screen instead.
+                ...(smallViewport
+                    ? { bounds: CONUS_BOUNDS, fitBoundsOptions: { padding: 16 } }
+                    : { center: MAP_CENTER, zoom: MAP_ZOOM }),
                 minZoom: MAP_MIN_ZOOM,
                 maxZoom: MAP_MAX_ZOOM,
                 attributionControl: false,
             });
 
+            // The compass is hidden, so a two-finger rotate/pitch would leave
+            // the map askew with no affordance to reset it.
+            map.current.touchZoomRotate.disableRotation();
+            map.current.touchPitch.disable();
+
             map.current.addControl(
                 new maplibregl.AttributionControl({ compact: true }),
                 "bottom-right",
             );
-            map.current.addControl(
-                new maplibregl.NavigationControl({ showCompass: false }),
-                "bottom-right",
-            );
+            if (!coarsePointer) {
+                // Pinch-zoom covers this on touch devices; skip the buttons.
+                map.current.addControl(
+                    new maplibregl.NavigationControl({ showCompass: false }),
+                    "bottom-right",
+                );
+            }
 
             map.current.on("load", async () => {
                 if (!map.current) return;

--- a/src/components/ui/ClickHint.tsx
+++ b/src/components/ui/ClickHint.tsx
@@ -1,15 +1,22 @@
 import { useMapStore } from "../../lib/store";
-import { DETAIL_PANEL_WIDTH, Z_INDEX } from "../../constants/layout";
+import { DETAIL_PANEL_WIDTH, HEADER_HEIGHT, Z_INDEX } from "../../constants/layout";
+import { useIsMobile } from "../../lib/useMediaQuery";
 
 export default function ClickHint() {
+    const isMobile = useIsMobile();
     const { hintVisible, panelOpen } = useMapStore();
+
+    // Mobile: top-center under the header (the bottom strip belongs to the
+    // legend and the desktop spot would collide with it).
+    const position: React.CSSProperties = isMobile
+        ? { top: HEADER_HEIGHT + 12, left: "50%", transform: "translateX(-50%)" }
+        : { bottom: 36, right: panelOpen ? 16 : DETAIL_PANEL_WIDTH - 4 };
 
     return (
         <div
             style={{
                 position: "absolute",
-                bottom: 36,
-                right: panelOpen ? 16 : DETAIL_PANEL_WIDTH - 4,
+                ...position,
                 zIndex: Z_INDEX.HEADER,
                 background: "var(--ink)",
                 color: "#fff",
@@ -17,11 +24,12 @@ export default function ClickHint() {
                 padding: "8px 12px",
                 borderRadius: 3,
                 pointerEvents: "none",
+                whiteSpace: "nowrap",
                 opacity: hintVisible ? 0.8 : 0,
                 transition: "opacity 0.3s, right 0.3s cubic-bezier(0.22,1,0.36,1)",
             }}
         >
-            Click any region to see details
+            {isMobile ? "Tap" : "Click"} any region to see details
         </div>
     );
 }

--- a/src/components/ui/DetailPanel/PanelContent.tsx
+++ b/src/components/ui/DetailPanel/PanelContent.tsx
@@ -119,6 +119,7 @@ export default function PanelContent({
                 </p>
                 <button
                     onClick={onClose}
+                    aria-label="Close details"
                     style={{
                         position: "absolute",
                         top: 16,

--- a/src/components/ui/DetailPanel/index.tsx
+++ b/src/components/ui/DetailPanel/index.tsx
@@ -1,15 +1,56 @@
+import { useRef } from "react";
 import { useMapStore } from "../../../lib/store";
 import {
     HEADER_HEIGHT,
     Z_INDEX,
     DETAIL_PANEL_WIDTH,
+    SHEET_MAX_WIDTH,
     PANEL_TRANSITION,
 } from "../../../constants/layout";
+import { useIsMobile } from "../../../lib/useMediaQuery";
+import SheetHandle from "../SheetHandle";
 import PanelContent from "./PanelContent";
 
 export default function DetailPanel() {
+    const isMobile = useIsMobile();
+    const sheetRef = useRef<HTMLDivElement>(null);
     const { panelOpen, selectedDetail, setSelectedRegion } = useMapStore();
     const close = () => setSelectedRegion(null, null);
+
+    // Mobile: bottom sheet sliding up over the map (the map above it stays
+    // interactive, so tapping another region swaps the content in place).
+    if (isMobile) {
+        return (
+            <div
+                ref={sheetRef}
+                className="sheet-detail"
+                style={{
+                    position: "absolute",
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    margin: "0 auto",
+                    maxWidth: SHEET_MAX_WIDTH,
+                    background: "var(--surface)",
+                    border: "1px solid var(--border)",
+                    borderBottom: "none",
+                    borderRadius: "14px 14px 0 0",
+                    boxShadow: "0 -6px 24px rgba(0,0,0,0.16)",
+                    zIndex: Z_INDEX.PANEL,
+                    display: "flex",
+                    flexDirection: "column",
+                    overflow: "hidden",
+                    paddingBottom: "env(safe-area-inset-bottom, 0px)",
+                    // 105% so the box shadow doesn't peek above the viewport edge.
+                    transform: panelOpen ? "translateY(0)" : "translateY(105%)",
+                    transition: `transform ${PANEL_TRANSITION}`,
+                }}
+            >
+                <SheetHandle sheetRef={sheetRef} />
+                {selectedDetail && <PanelContent detail={selectedDetail} onClose={close} />}
+            </div>
+        );
+    }
 
     return (
         <div

--- a/src/components/ui/ExportModal.tsx
+++ b/src/components/ui/ExportModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Z_INDEX } from "../../constants/layout";
+import { useIsMobile } from "../../lib/useMediaQuery";
 import { useMapStore } from "../../lib/store";
 import { getAnnualDataForLevel, getMonthlyDataForLevel } from "../../lib/dataService";
 import { buildCsvRows, csvFilename, downloadCsv, rowsToCsv } from "../../lib/export/csv";
@@ -33,6 +34,7 @@ const PREVIEW_DEBOUNCE_MS = 300;
 const PREVIEW_SCALE = 0.25;
 
 export default function ExportModal({ open, onClose }: ExportModalProps) {
+    const isMobile = useIsMobile();
     const activeLayer = useMapStore((s) => s.activeLayer);
     const selectedYear = useMapStore((s) => s.selectedYear);
     const selectedMonth = useMapStore((s) => s.selectedMonth);
@@ -152,11 +154,12 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                padding: 24,
+                padding: isMobile ? 12 : 24,
             }}
         >
             <div
                 onClick={(e) => e.stopPropagation()}
+                className="modal-card"
                 style={{
                     position: "relative",
                     background: "var(--surface)",
@@ -165,7 +168,6 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
                     boxShadow: "0 8px 40px rgba(0,0,0,0.18)",
                     width: "100%",
                     maxWidth: 640,
-                    maxHeight: "85vh",
                     display: "flex",
                     flexDirection: "column",
                     overflow: "hidden",
@@ -173,7 +175,7 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
             >
                 <div
                     style={{
-                        padding: "24px 24px 18px",
+                        padding: isMobile ? "18px 16px 14px" : "24px 24px 18px",
                         borderBottom: "1px solid var(--border)",
                         flexShrink: 0,
                     }}
@@ -242,7 +244,9 @@ export default function ExportModal({ open, onClose }: ExportModalProps) {
                     style={{
                         flex: 1,
                         overflowY: "auto",
-                        padding: "20px 24px 24px",
+                        padding: isMobile
+                            ? "16px 16px calc(20px + env(safe-area-inset-bottom, 0px))"
+                            : "20px 24px 24px",
                         display: "flex",
                         flexDirection: "column",
                         gap: 18,

--- a/src/components/ui/FilterSheet.tsx
+++ b/src/components/ui/FilterSheet.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useRef } from "react";
+import { useMapStore } from "../../lib/store";
+import { LAYER_CONFIGS, LAYER_ORDER, GEO_LEVELS, METRIC_OPTIONS } from "../../constants/map";
+import { AVAILABLE_YEARS, MONTH_OPTIONS } from "../../constants/time";
+import { Z_INDEX, SHEET_MAX_WIDTH, PANEL_TRANSITION } from "../../constants/layout";
+import SheetHandle from "./SheetHandle";
+
+// Mobile replacement for the four floating desktop controls (LayerControl,
+// GeoLevelControl, MetricControl, TimeControl): one bottom sheet with
+// touch-sized chips. Selections apply immediately, same as desktop — "Done"
+// just dismisses the sheet.
+export default function FilterSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+    const {
+        activeLayer,
+        setActiveLayer,
+        geoLevel,
+        setGeoLevel,
+        metric,
+        setMetric,
+        selectedYear,
+        setSelectedYear,
+        selectedMonth,
+        setSelectedMonth,
+        monthlyDataLoaded,
+    } = useMapStore();
+    const sheetRef = useRef<HTMLDivElement>(null);
+    const loadingMonthly = selectedMonth !== null && !monthlyDataLoaded;
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    return (
+        <>
+            {/* Backdrop */}
+            <div
+                onClick={onClose}
+                style={{
+                    position: "fixed",
+                    inset: 0,
+                    zIndex: Z_INDEX.SHEET,
+                    background: "rgba(26,25,23,0.35)",
+                    opacity: open ? 1 : 0,
+                    pointerEvents: open ? "auto" : "none",
+                    transition: "opacity 0.25s",
+                }}
+            />
+
+            {/* Sheet */}
+            <div
+                ref={sheetRef}
+                className="sheet-filters"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Map filters"
+                style={{
+                    position: "fixed",
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    margin: "0 auto",
+                    maxWidth: SHEET_MAX_WIDTH,
+                    zIndex: Z_INDEX.SHEET,
+                    display: "flex",
+                    flexDirection: "column",
+                    background: "var(--surface)",
+                    border: "1px solid var(--border)",
+                    borderBottom: "none",
+                    borderRadius: "14px 14px 0 0",
+                    boxShadow: "0 -6px 24px rgba(0,0,0,0.16)",
+                    transform: open ? "translateY(0)" : "translateY(105%)",
+                    transition: `transform ${PANEL_TRANSITION}`,
+                }}
+            >
+                <SheetHandle sheetRef={sheetRef} />
+
+                {/* Scrollable filter sections */}
+                <div
+                    style={{
+                        flex: 1,
+                        overflowY: "auto",
+                        padding: "8px 16px 16px",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 18,
+                    }}
+                >
+                    <Section title="Geography">
+                        <div style={{ display: "flex", gap: 6 }}>
+                            {GEO_LEVELS.map(({ key, label }) => (
+                                <Chip
+                                    key={key}
+                                    label={label}
+                                    active={key === geoLevel}
+                                    onClick={() => setGeoLevel(key)}
+                                    grow
+                                />
+                            ))}
+                        </div>
+                    </Section>
+
+                    <Section title="Metric">
+                        <div style={{ display: "flex", gap: 6 }}>
+                            {METRIC_OPTIONS.map(({ key, label }) => (
+                                <Chip
+                                    key={key}
+                                    label={label}
+                                    active={key === metric}
+                                    onClick={() => setMetric(key)}
+                                    grow
+                                />
+                            ))}
+                        </div>
+                    </Section>
+
+                    <Section title="Year">
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                            {AVAILABLE_YEARS.map((year) => (
+                                <Chip
+                                    key={year}
+                                    label={year}
+                                    active={year === selectedYear}
+                                    onClick={() => setSelectedYear(year)}
+                                />
+                            ))}
+                        </div>
+                    </Section>
+
+                    <Section title="Month" hint={loadingMonthly ? "loading…" : undefined}>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                            {MONTH_OPTIONS.map(({ value, label }) => (
+                                <Chip
+                                    key={label}
+                                    label={label}
+                                    active={value === selectedMonth}
+                                    onClick={() => setSelectedMonth(value)}
+                                />
+                            ))}
+                        </div>
+                    </Section>
+
+                    <Section title="Procedure Category">
+                        <div
+                            style={{
+                                border: "1px solid var(--border)",
+                                borderRadius: 6,
+                                overflow: "hidden",
+                            }}
+                        >
+                            {LAYER_ORDER.map((key, i) => {
+                                const cfg = LAYER_CONFIGS[key];
+                                const isActive = key === activeLayer;
+                                return (
+                                    <button
+                                        key={key}
+                                        onClick={() => setActiveLayer(key)}
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            gap: 10,
+                                            width: "100%",
+                                            minHeight: 44,
+                                            padding: "10px 12px",
+                                            background: isActive
+                                                ? "var(--accent-light)"
+                                                : "transparent",
+                                            border: "none",
+                                            borderTop: i === 0 ? "none" : "1px solid var(--border)",
+                                            cursor: "pointer",
+                                            textAlign: "left",
+                                            fontFamily: "var(--ff-sans)",
+                                        }}
+                                    >
+                                        <div
+                                            style={{
+                                                width: 10,
+                                                height: 10,
+                                                borderRadius: "50%",
+                                                background: cfg.accent,
+                                                flexShrink: 0,
+                                            }}
+                                        />
+                                        <div style={{ flex: 1 }}>
+                                            <span
+                                                style={{
+                                                    display: "block",
+                                                    fontSize: 13,
+                                                    fontWeight: 500,
+                                                    color: isActive
+                                                        ? "var(--accent)"
+                                                        : "var(--ink)",
+                                                    lineHeight: 1.25,
+                                                }}
+                                            >
+                                                {cfg.label}
+                                            </span>
+                                            <span
+                                                style={{
+                                                    display: "block",
+                                                    fontSize: 11,
+                                                    color: "var(--ink-dim)",
+                                                    marginTop: 1,
+                                                }}
+                                            >
+                                                {cfg.description}
+                                            </span>
+                                        </div>
+                                        <span
+                                            style={{
+                                                fontSize: 13,
+                                                color: "var(--accent)",
+                                                opacity: isActive ? 1 : 0,
+                                            }}
+                                        >
+                                            ✓
+                                        </span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </Section>
+                </div>
+
+                {/* Sticky footer */}
+                <div
+                    style={{
+                        flexShrink: 0,
+                        padding: "12px 16px",
+                        paddingBottom: "calc(12px + env(safe-area-inset-bottom, 0px))",
+                        borderTop: "1px solid var(--border)",
+                        background: "var(--surface)",
+                    }}
+                >
+                    <button
+                        onClick={onClose}
+                        style={{
+                            width: "100%",
+                            minHeight: 44,
+                            fontSize: 14,
+                            fontWeight: 600,
+                            fontFamily: "var(--ff-sans)",
+                            background: "var(--accent)",
+                            color: "#fff",
+                            border: "none",
+                            borderRadius: 6,
+                            cursor: "pointer",
+                            letterSpacing: "0.01em",
+                        }}
+                    >
+                        Done
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+}
+
+function Section({
+    title,
+    hint,
+    children,
+}: {
+    title: string;
+    hint?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div>
+            <p
+                style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: "0.12em",
+                    textTransform: "uppercase",
+                    color: "var(--ink-dim)",
+                    marginBottom: 8,
+                }}
+            >
+                {title}
+                {hint && (
+                    <span
+                        style={{
+                            marginLeft: 8,
+                            fontWeight: 500,
+                            letterSpacing: "0.02em",
+                            textTransform: "none",
+                        }}
+                    >
+                        {hint}
+                    </span>
+                )}
+            </p>
+            {children}
+        </div>
+    );
+}
+
+function Chip({
+    label,
+    active,
+    onClick,
+    grow,
+}: {
+    label: string;
+    active: boolean;
+    onClick: () => void;
+    grow?: boolean;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            style={{
+                flex: grow ? 1 : undefined,
+                minHeight: 40,
+                padding: "8px 14px",
+                fontSize: 13,
+                fontWeight: active ? 600 : 500,
+                fontFamily: "var(--ff-sans)",
+                color: active ? "var(--accent)" : "var(--ink-mid)",
+                background: active ? "var(--accent-light)" : "var(--surface2)",
+                border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 6,
+                cursor: "pointer",
+                transition: "background 0.12s, color 0.12s, border-color 0.12s",
+            }}
+        >
+            {label}
+        </button>
+    );
+}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -3,12 +3,14 @@ import LayerControl from "./LayerControl";
 import GeoLevelControl from "./GeoLevelControl";
 import MetricControl from "./MetricControl";
 import TimeControl from "./TimeControl";
+import FilterSheet from "./FilterSheet";
 import DetailPanel from "./DetailPanel/index";
 import Tooltip from "./Tooltip";
 import Legend from "./Legend";
 import ClickHint from "./ClickHint";
 import InfoModal from "./InfoModal";
 import { HEADER_HEIGHT, Z_INDEX } from "../../constants/layout";
+import { useIsMobile } from "../../lib/useMediaQuery";
 
 // Export deps (d3-geo, topojson-client, papaparse) are only needed once the
 // user opens the modal — load them lazily so they stay out of the critical
@@ -17,9 +19,13 @@ import { HEADER_HEIGHT, Z_INDEX } from "../../constants/layout";
 const ExportModal = lazy(() => import("./ExportModal"));
 
 export default function Header() {
+    const isMobile = useIsMobile();
     const [exportOpen, setExportOpen] = useState(false);
+    const [filtersOpen, setFiltersOpen] = useState(false);
     const openExport = useCallback(() => setExportOpen(true), []);
     const closeExport = useCallback(() => setExportOpen(false), []);
+    const openFilters = useCallback(() => setFiltersOpen(true), []);
+    const closeFilters = useCallback(() => setFiltersOpen(false), []);
 
     return (
         <>
@@ -33,7 +39,8 @@ export default function Header() {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "space-between",
-                    padding: "0 20px",
+                    gap: 10,
+                    padding: isMobile ? "0 12px" : "0 20px",
                     height: HEADER_HEIGHT,
                     background: "var(--surface)",
                     borderBottom: "1px solid var(--border)",
@@ -45,65 +52,63 @@ export default function Header() {
                         display: "flex",
                         alignItems: "baseline",
                         gap: 12,
+                        minWidth: 0,
                     }}
                 >
                     <h1
                         style={{
                             fontFamily: "var(--ff-sans)",
-                            fontSize: 17,
+                            fontSize: isMobile ? 15 : 17,
                             fontWeight: 600,
                             letterSpacing: "-0.01em",
                             color: "var(--ink)",
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
                         }}
                     >
                         Medicaid Dental Utilization
                     </h1>
-                    <span
-                        style={{
-                            fontSize: 11,
-                            color: "var(--ink-dim)",
-                            letterSpacing: "0.02em",
-                        }}
-                    >
-                        United States · State, County & ZIP3 Areas
-                    </span>
+                    {!isMobile && (
+                        <span
+                            style={{
+                                fontSize: 11,
+                                color: "var(--ink-dim)",
+                                letterSpacing: "0.02em",
+                            }}
+                        >
+                            United States · State, County & ZIP3 Areas
+                        </span>
+                    )}
                 </div>
-                <button
-                    onClick={openExport}
-                    style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
-                        padding: "6px 12px",
-                        background: "var(--surface2)",
-                        border: "1px solid var(--border)",
-                        borderRadius: 4,
-                        cursor: "pointer",
-                        fontFamily: "var(--ff-sans)",
-                        fontSize: 12,
-                        fontWeight: 600,
-                        color: "var(--ink)",
-                        letterSpacing: "0.01em",
-                        transition: "background 0.12s, border-color 0.12s",
-                    }}
-                    onMouseEnter={(e) => {
-                        (e.currentTarget as HTMLButtonElement).style.background = "var(--surface)";
-                        (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--accent)";
-                    }}
-                    onMouseLeave={(e) => {
-                        (e.currentTarget as HTMLButtonElement).style.background = "var(--surface2)";
-                        (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--border)";
-                    }}
-                >
-                    <span style={{ fontSize: 13, lineHeight: 1, color: "var(--accent)" }}>↓</span>
-                    Export
-                </button>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                    {isMobile && (
+                        <HeaderButton onClick={openFilters} ariaLabel="Open map filters">
+                            <span style={{ fontSize: 13, lineHeight: 1, color: "var(--accent)" }}>
+                                ☰
+                            </span>
+                            Filters
+                        </HeaderButton>
+                    )}
+                    <HeaderButton onClick={openExport} ariaLabel="Export the current view">
+                        <span style={{ fontSize: 13, lineHeight: 1, color: "var(--accent)" }}>
+                            ↓
+                        </span>
+                        {!isMobile && "Export"}
+                    </HeaderButton>
+                </div>
             </header>
 
-            <LayerControl />
-            <GeoLevelControl />
-            <MetricControl />
-            <TimeControl />
+            {isMobile ? (
+                <FilterSheet open={filtersOpen} onClose={closeFilters} />
+            ) : (
+                <>
+                    <LayerControl />
+                    <GeoLevelControl />
+                    <MetricControl />
+                    <TimeControl />
+                </>
+            )}
             <Legend />
             <Tooltip />
             <DetailPanel />
@@ -115,5 +120,49 @@ export default function Header() {
                 </Suspense>
             )}
         </>
+    );
+}
+
+function HeaderButton({
+    onClick,
+    ariaLabel,
+    children,
+}: {
+    onClick: () => void;
+    ariaLabel: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            aria-label={ariaLabel}
+            style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "8px 12px",
+                minHeight: 34,
+                background: "var(--surface2)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                cursor: "pointer",
+                fontFamily: "var(--ff-sans)",
+                fontSize: 12,
+                fontWeight: 600,
+                color: "var(--ink)",
+                letterSpacing: "0.01em",
+                transition: "background 0.12s, border-color 0.12s",
+            }}
+            onMouseEnter={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = "var(--surface)";
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--accent)";
+            }}
+            onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = "var(--surface2)";
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--border)";
+            }}
+        >
+            {children}
+        </button>
     );
 }

--- a/src/components/ui/InfoModal.tsx
+++ b/src/components/ui/InfoModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { Z_INDEX } from "../../constants/layout";
 import { INFO_MODAL_TITLE, INFO_MODAL_BODY, INFO_MODAL_NOTES } from "../../constants/infoModal";
+import { useIsMobile } from "../../lib/useMediaQuery";
 
 export default function InfoModal() {
+    const isMobile = useIsMobile();
     const [visible, setVisible] = useState(true);
 
     const close = useCallback(() => setVisible(false), []);
@@ -30,11 +32,12 @@ export default function InfoModal() {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                padding: 24,
+                padding: isMobile ? 12 : 24,
             }}
         >
             <div
                 onClick={(e) => e.stopPropagation()}
+                className="modal-card"
                 style={{
                     position: "relative",
                     background: "var(--surface)",
@@ -43,7 +46,6 @@ export default function InfoModal() {
                     boxShadow: "0 8px 40px rgba(0,0,0,0.18)",
                     width: "100%",
                     maxWidth: 580,
-                    maxHeight: "85vh",
                     display: "flex",
                     flexDirection: "column",
                     overflow: "hidden",
@@ -52,7 +54,7 @@ export default function InfoModal() {
                 {/* Header */}
                 <div
                     style={{
-                        padding: "24px 24px 18px",
+                        padding: isMobile ? "18px 16px 14px" : "24px 24px 18px",
                         borderBottom: "1px solid var(--border)",
                         flexShrink: 0,
                     }}
@@ -111,7 +113,7 @@ export default function InfoModal() {
                     style={{
                         flex: 1,
                         overflowY: "auto",
-                        padding: "20px 24px 28px",
+                        padding: isMobile ? "16px 16px 20px" : "20px 24px 28px",
                         display: "flex",
                         flexDirection: "column",
                         gap: 20,
@@ -191,7 +193,10 @@ export default function InfoModal() {
                 {/* Footer */}
                 <div
                     style={{
-                        padding: "14px 24px",
+                        padding: isMobile ? "12px 16px" : "14px 24px",
+                        paddingBottom: isMobile
+                            ? "calc(12px + env(safe-area-inset-bottom, 0px))"
+                            : undefined,
                         borderTop: "1px solid var(--border)",
                         flexShrink: 0,
                         display: "flex",
@@ -201,7 +206,7 @@ export default function InfoModal() {
                     <button
                         onClick={close}
                         style={{
-                            padding: "7px 20px",
+                            padding: isMobile ? "10px 20px" : "7px 20px",
                             fontSize: 13,
                             fontWeight: 600,
                             fontFamily: "var(--ff-sans)",

--- a/src/components/ui/Legend.tsx
+++ b/src/components/ui/Legend.tsx
@@ -3,8 +3,10 @@ import { LAYER_CONFIGS } from "../../constants/map";
 import { CHOROPLETH_COLORS } from "../../lib/mapStyles";
 import { formatStop, formatRatio } from "../../lib/formatters";
 import { Z_INDEX, PANEL_SHADOW } from "../../constants/layout";
+import { useIsMobile } from "../../lib/useMediaQuery";
 
 export default function Legend() {
+    const isMobile = useIsMobile();
     const { activeLayer, metric, colorStops } = useMapStore();
     const cfg = LAYER_CONFIGS[activeLayer];
     const fmt = metric === "enrollees" ? formatRatio : formatStop;
@@ -15,14 +17,15 @@ export default function Legend() {
         <div
             style={{
                 position: "absolute",
-                bottom: 36,
-                left: 16,
+                bottom: isMobile ? "calc(12px + env(safe-area-inset-bottom, 0px))" : 36,
+                left: isMobile ? 12 : 16,
                 zIndex: Z_INDEX.HEADER,
                 background: "var(--surface)",
                 border: "1px solid var(--border)",
                 borderRadius: 4,
-                padding: "12px 14px",
-                minWidth: 200,
+                padding: isMobile ? "8px 10px" : "12px 14px",
+                minWidth: isMobile ? 150 : 200,
+                maxWidth: isMobile ? "60vw" : undefined,
                 boxShadow: PANEL_SHADOW,
             }}
         >
@@ -64,17 +67,19 @@ export default function Legend() {
                     {hasStops ? `${fmt(colorStops[colorStops.length - 1])}+` : "—"}
                 </span>
             </div>
-            <p
-                style={{
-                    fontSize: 9,
-                    color: "var(--ink-dim)",
-                    marginTop: 8,
-                }}
-            >
-                {metric === "enrollees"
-                    ? "Capped at 95th percentile; outliers saturate"
-                    : "Scale adjusts to the current view"}
-            </p>
+            {!isMobile && (
+                <p
+                    style={{
+                        fontSize: 9,
+                        color: "var(--ink-dim)",
+                        marginTop: 8,
+                    }}
+                >
+                    {metric === "enrollees"
+                        ? "Capped at 95th percentile; outliers saturate"
+                        : "Scale adjusts to the current view"}
+                </p>
+            )}
         </div>
     );
 }

--- a/src/components/ui/MetricControl.tsx
+++ b/src/components/ui/MetricControl.tsx
@@ -1,11 +1,6 @@
 import { useMapStore } from "../../lib/store";
 import { Z_INDEX, HEADER_HEIGHT } from "../../constants/layout";
-import type { Metric } from "../../lib/types";
-
-const METRICS: { key: Metric; label: string }[] = [
-    { key: "claims", label: "Volume" },
-    { key: "enrollees", label: "Per Medicaid enrollee" },
-];
+import { METRIC_OPTIONS } from "../../constants/map";
 
 // Sits directly under the geography toggle (GeoLevelControl) at top-center.
 export default function MetricControl() {
@@ -28,7 +23,7 @@ export default function MetricControl() {
                 boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
             }}
         >
-            {METRICS.map(({ key, label }) => {
+            {METRIC_OPTIONS.map(({ key, label }) => {
                 const isActive = key === metric;
                 return (
                     <button

--- a/src/components/ui/SheetHandle.tsx
+++ b/src/components/ui/SheetHandle.tsx
@@ -1,0 +1,33 @@
+import { useSheetDrag } from "../../lib/useSheetDrag";
+
+// Grab handle for bottom sheets: dragging it resizes the sheet between
+// SHEET_MIN_HEIGHT and most of the viewport. Purely a resize affordance —
+// dismissing stays on the backdrop / Done / ✕ paths.
+export default function SheetHandle({ sheetRef }: { sheetRef: React.RefObject<HTMLDivElement> }) {
+    const dragHandlers = useSheetDrag(sheetRef);
+
+    return (
+        <div
+            {...dragHandlers}
+            style={{
+                display: "flex",
+                justifyContent: "center",
+                // Generous hit area around the 4px pill so the drag is easy
+                // to start with a thumb.
+                padding: "12px 0 10px",
+                flexShrink: 0,
+                touchAction: "none",
+                cursor: "grab",
+            }}
+        >
+            <div
+                style={{
+                    width: 36,
+                    height: 4,
+                    borderRadius: 2,
+                    background: "var(--border-dark)",
+                }}
+            />
+        </div>
+    );
+}

--- a/src/components/ui/TimeControl.tsx
+++ b/src/components/ui/TimeControl.tsx
@@ -1,25 +1,6 @@
 import { useMapStore } from "../../lib/store";
-import { AVAILABLE_YEARS } from "../../constants/time";
+import { AVAILABLE_YEARS, MONTH_OPTIONS } from "../../constants/time";
 import { Z_INDEX, HEADER_HEIGHT } from "../../constants/layout";
-
-// "All" + 12 months. Picking a month repaints the choropleth with monthly
-// values (lazy-loads the monthly NDJSON on first use). "All" reverts to the
-// annual view.
-const MONTHS: { value: string | null; label: string }[] = [
-    { value: null, label: "All" },
-    { value: "01", label: "Jan" },
-    { value: "02", label: "Feb" },
-    { value: "03", label: "Mar" },
-    { value: "04", label: "Apr" },
-    { value: "05", label: "May" },
-    { value: "06", label: "Jun" },
-    { value: "07", label: "Jul" },
-    { value: "08", label: "Aug" },
-    { value: "09", label: "Sep" },
-    { value: "10", label: "Oct" },
-    { value: "11", label: "Nov" },
-    { value: "12", label: "Dec" },
-];
 
 // Sits below GeoLevelControl + MetricControl. Two stacked rows (year + month)
 // so the three view controls — geography, metric, time — live together.
@@ -64,7 +45,7 @@ export default function TimeControl() {
 
             {/* Month row */}
             <div style={{ display: "flex", gap: 2, alignItems: "center" }}>
-                {MONTHS.map(({ value, label }) => {
+                {MONTH_OPTIONS.map(({ value, label }) => {
                     const isActive = value === selectedMonth;
                     return (
                         <button

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -2,11 +2,16 @@ import { useMapStore } from "../../lib/store";
 import { LAYER_CONFIGS } from "../../constants/map";
 import { Z_INDEX } from "../../constants/layout";
 import { formatRatio } from "../../lib/formatters";
+import { useIsCoarsePointer } from "../../lib/useMediaQuery";
 
 export default function Tooltip() {
+    const coarsePointer = useIsCoarsePointer();
     const { hoveredRegion, hoveredValue, hoveredPoint, activeLayer, metric } = useMapStore();
     const cfg = LAYER_CONFIGS[activeLayer];
 
+    // Touch devices have no hover; a tap would pin the tooltip at the tap
+    // point with no mouseleave to clear it. The detail sheet covers tap.
+    if (coarsePointer) return null;
     if (!hoveredRegion || hoveredPoint === null) return null;
 
     const valueLabel =

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,9 +1,32 @@
 export const HEADER_HEIGHT = 52;
 export const DETAIL_PANEL_WIDTH = 360;
 
+// At or below this width the floating control chrome (category list, centered
+// geo/metric/time controls) collapses into the Filters bottom sheet and the
+// detail panel becomes a bottom sheet. 900 keeps iPad portrait (≤834px) on the
+// touch layout — the centered TimeControl (~380px wide) collides with the
+// 220px category panel below ~850px — while iPad landscape (1024px) gets the
+// full desktop chrome.
+export const MOBILE_BREAKPOINT = 900;
+export const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`;
+// Touch-first devices (no hover) — used to suppress hover-only affordances
+// like the cursor tooltip and the zoom-button control.
+export const COARSE_POINTER_QUERY = "(hover: none)";
+
+// Bottom sheets (filters, mobile detail panel) span the viewport on phones but
+// cap out centered on tablet-portrait widths so they don't stretch edge-to-edge.
+export const SHEET_MAX_WIDTH = 560;
+
+// Drag-resize bounds for bottom sheets: never shorter than the grab handle
+// plus the footer strip, never taller than most of the viewport.
+export const SHEET_MIN_HEIGHT = 140;
+export const SHEET_MAX_VIEWPORT_FRACTION = 0.92;
+
 export const Z_INDEX = {
     HEADER: 50,
     PANEL: 60,
+    // Filter sheet sits above the detail panel but below tooltip/modals.
+    SHEET: 90,
     TOOLTIP: 200,
     MODAL: 300,
 } as const;

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,10 +1,17 @@
-import type { LayerKey, LayerConfig, GeoLevel } from "../lib/types";
+import type { LayerKey, LayerConfig, GeoLevel, Metric } from "../lib/types";
 
 // ── Map viewport ──────────────────────────────────────────────
 export const MAP_CENTER: [number, number] = [-98.5, 39.8];
 export const MAP_ZOOM = 4;
 export const MAP_MIN_ZOOM = 2;
 export const MAP_MAX_ZOOM = 14;
+
+// Continental-US bounds. Small screens fit the initial view to these instead
+// of MAP_CENTER/MAP_ZOOM, which crop both seaboards on a portrait phone.
+export const CONUS_BOUNDS: [[number, number], [number, number]] = [
+    [-124.9, 24.4],
+    [-66.9, 49.4],
+];
 
 // ── Tile sources & layers ─────────────────────────────────────
 export const STATES_SOURCE = "states-source";
@@ -44,6 +51,12 @@ export const GEO_LEVELS: { key: GeoLevel; label: string }[] = [
     { key: "state", label: "State" },
     { key: "county", label: "County" },
     { key: "zip3", label: "ZIP3" },
+];
+
+// ── Metric toggle (shared by MetricControl and the mobile FilterSheet) ──
+export const METRIC_OPTIONS: { key: Metric; label: string }[] = [
+    { key: "claims", label: "Volume" },
+    { key: "enrollees", label: "Per Medicaid enrollee" },
 ];
 
 // ── Data file paths (relative to BASE_URL) ────────────────────

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,6 +1,25 @@
 export const AVAILABLE_YEARS = ["2018", "2019", "2020", "2021", "2022", "2023", "2024"];
 export const DEFAULT_YEAR = "2024";
 
+// "All" + 12 months, shared by TimeControl and the mobile FilterSheet.
+// Picking a month repaints the choropleth with monthly values (lazy-loads the
+// monthly NDJSON on first use); null ("All") reverts to the annual view.
+export const MONTH_OPTIONS: { value: string | null; label: string }[] = [
+    { value: null, label: "All" },
+    { value: "01", label: "Jan" },
+    { value: "02", label: "Feb" },
+    { value: "03", label: "Mar" },
+    { value: "04", label: "Apr" },
+    { value: "05", label: "May" },
+    { value: "06", label: "Jun" },
+    { value: "07", label: "Jul" },
+    { value: "08", label: "Aug" },
+    { value: "09", label: "Sep" },
+    { value: "10", label: "Oct" },
+    { value: "11", label: "Nov" },
+    { value: "12", label: "Dec" },
+];
+
 export const MONTH_NAMES = [
     "January",
     "February",

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,38 @@ body,
     font-family: var(--ff-sans);
 }
 
+/* On touch devices, suppress the grey tap flash and the 300 ms double-tap
+   delay so the control chips feel immediate. No effect on desktop. */
+button {
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* dvh (visual-viewport height) with a vh fallback for older engines.
+   A duplicate-property fallback can't be expressed in inline styles, so the
+   few height rules that need it live here as utility classes. dvh matters on
+   mobile Safari/Chrome, where 100vh includes the area behind the collapsing
+   browser toolbar and pushes bottom-anchored UI off screen. */
+.app-shell {
+    height: 100vh;
+    height: 100dvh;
+}
+
+.sheet-detail {
+    height: 60vh;
+    height: 60dvh;
+}
+
+.sheet-filters {
+    max-height: 78vh;
+    max-height: 78dvh;
+}
+
+.modal-card {
+    max-height: 85vh;
+    max-height: 85dvh;
+}
+
 /* MapLibre overrides */
 .maplibregl-ctrl-group {
     background: var(--surface) !important;

--- a/src/lib/useMediaQuery.test.ts
+++ b/src/lib/useMediaQuery.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMediaQuery } from "./useMediaQuery";
+
+// jsdom has no matchMedia; install a controllable stub.
+function installMatchMedia(initialMatches: boolean) {
+    const listeners = new Set<() => void>();
+    let matches = initialMatches;
+    const mql = {
+        get matches() {
+            return matches;
+        },
+        addEventListener: (_type: string, cb: () => void) => listeners.add(cb),
+        removeEventListener: (_type: string, cb: () => void) => listeners.delete(cb),
+    };
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mql));
+    return {
+        setMatches(next: boolean) {
+            matches = next;
+            listeners.forEach((cb) => cb());
+        },
+        listenerCount: () => listeners.size,
+    };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("useMediaQuery", () => {
+    it("reflects the initial match state", () => {
+        installMatchMedia(true);
+        const { result } = renderHook(() => useMediaQuery("(max-width: 900px)"));
+        expect(result.current).toBe(true);
+    });
+
+    it("re-renders when the query flips", () => {
+        const media = installMatchMedia(false);
+        const { result } = renderHook(() => useMediaQuery("(max-width: 900px)"));
+        expect(result.current).toBe(false);
+
+        act(() => media.setMatches(true));
+        expect(result.current).toBe(true);
+
+        act(() => media.setMatches(false));
+        expect(result.current).toBe(false);
+    });
+
+    it("removes its listener on unmount", () => {
+        const media = installMatchMedia(false);
+        const { unmount } = renderHook(() => useMediaQuery("(max-width: 900px)"));
+        expect(media.listenerCount()).toBe(1);
+        unmount();
+        expect(media.listenerCount()).toBe(0);
+    });
+
+    it("returns false when matchMedia is unavailable", () => {
+        vi.stubGlobal("matchMedia", undefined);
+        const { result } = renderHook(() => useMediaQuery("(max-width: 900px)"));
+        expect(result.current).toBe(false);
+    });
+});

--- a/src/lib/useMediaQuery.ts
+++ b/src/lib/useMediaQuery.ts
@@ -1,0 +1,34 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { MOBILE_MEDIA_QUERY, COARSE_POINTER_QUERY } from "../constants/layout";
+
+/**
+ * Reactive media-query match. Re-renders when the query flips (rotation,
+ * window resize across the breakpoint, attaching a mouse to a tablet).
+ * Returns false in environments without matchMedia (jsdom).
+ */
+export function useMediaQuery(query: string): boolean {
+    const subscribe = useCallback(
+        (onChange: () => void) => {
+            if (typeof window.matchMedia !== "function") return () => {};
+            const mql = window.matchMedia(query);
+            mql.addEventListener("change", onChange);
+            return () => mql.removeEventListener("change", onChange);
+        },
+        [query],
+    );
+    const getSnapshot = useCallback(
+        () => typeof window.matchMedia === "function" && window.matchMedia(query).matches,
+        [query],
+    );
+    return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Compact layout: floating control chrome collapses into bottom sheets. */
+export function useIsMobile(): boolean {
+    return useMediaQuery(MOBILE_MEDIA_QUERY);
+}
+
+/** Touch-first device (no hover) — suppress hover-only affordances. */
+export function useIsCoarsePointer(): boolean {
+    return useMediaQuery(COARSE_POINTER_QUERY);
+}

--- a/src/lib/useSheetDrag.test.tsx
+++ b/src/lib/useSheetDrag.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { useRef } from "react";
+import { useSheetDrag } from "./useSheetDrag";
+import { SHEET_MIN_HEIGHT, SHEET_MAX_VIEWPORT_FRACTION } from "../constants/layout";
+
+const START_HEIGHT = 400;
+
+function Harness() {
+    const sheetRef = useRef<HTMLDivElement>(null);
+    const dragHandlers = useSheetDrag(sheetRef);
+    return (
+        <div data-testid="sheet" ref={sheetRef}>
+            <div data-testid="handle" {...dragHandlers} />
+        </div>
+    );
+}
+
+// jsdom layout always reports 0×0; pin the sheet's measured height.
+function renderSheet() {
+    const utils = render(<Harness />);
+    const sheet = utils.getByTestId("sheet");
+    const handle = utils.getByTestId("handle");
+    sheet.getBoundingClientRect = () => ({ height: START_HEIGHT }) as DOMRect;
+    return { sheet, handle };
+}
+
+// jsdom has no PointerEvent constructor; a MouseEvent with the pointer event
+// type carries clientY through, and pointerId is pinned on afterwards.
+function firePointer(
+    el: Element,
+    type: "pointerdown" | "pointermove" | "pointerup",
+    init: { pointerId: number; clientY?: number },
+) {
+    const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientY: init.clientY ?? 0,
+    });
+    Object.defineProperty(event, "pointerId", { value: init.pointerId });
+    fireEvent(el, event);
+}
+
+describe("useSheetDrag", () => {
+    it("grows the sheet when dragging up", () => {
+        const { sheet, handle } = renderSheet();
+        firePointer(handle, "pointerdown", { pointerId: 1, clientY: 500 });
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: 420 });
+        expect(sheet.style.height).toBe(`${START_HEIGHT + 80}px`);
+        expect(sheet.style.maxHeight).toBe("none");
+    });
+
+    it("shrinks the sheet when dragging down, clamped to the minimum", () => {
+        const { sheet, handle } = renderSheet();
+        firePointer(handle, "pointerdown", { pointerId: 1, clientY: 500 });
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: 560 });
+        expect(sheet.style.height).toBe(`${START_HEIGHT - 60}px`);
+
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: 5000 });
+        expect(sheet.style.height).toBe(`${SHEET_MIN_HEIGHT}px`);
+    });
+
+    it("clamps to the viewport-fraction maximum when dragging up", () => {
+        const { sheet, handle } = renderSheet();
+        firePointer(handle, "pointerdown", { pointerId: 1, clientY: 500 });
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: -5000 });
+        expect(parseFloat(sheet.style.height)).toBeCloseTo(
+            window.innerHeight * SHEET_MAX_VIEWPORT_FRACTION,
+        );
+    });
+
+    it("ignores moves from a different pointer", () => {
+        const { sheet, handle } = renderSheet();
+        firePointer(handle, "pointerdown", { pointerId: 1, clientY: 500 });
+        firePointer(handle, "pointermove", { pointerId: 2, clientY: 300 });
+        expect(sheet.style.height).toBe("");
+    });
+
+    it("stops resizing after the pointer is released", () => {
+        const { sheet, handle } = renderSheet();
+        firePointer(handle, "pointerdown", { pointerId: 1, clientY: 500 });
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: 450 });
+        const heightAtRelease = sheet.style.height;
+        firePointer(handle, "pointerup", { pointerId: 1 });
+        firePointer(handle, "pointermove", { pointerId: 1, clientY: 200 });
+        expect(sheet.style.height).toBe(heightAtRelease);
+    });
+});

--- a/src/lib/useSheetDrag.ts
+++ b/src/lib/useSheetDrag.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef } from "react";
+import { SHEET_MIN_HEIGHT, SHEET_MAX_VIEWPORT_FRACTION } from "../constants/layout";
+
+interface DragState {
+    pointerId: number;
+    startY: number;
+    startHeight: number;
+}
+
+/**
+ * Drag-to-resize for a bottom sheet. Returns pointer handlers to spread on
+ * the sheet's grab handle; dragging sets an explicit inline height on
+ * `sheetRef` (overriding the sheet's CSS-class default), clamped between
+ * SHEET_MIN_HEIGHT and SHEET_MAX_VIEWPORT_FRACTION of the viewport. Dragging
+ * never dismisses the sheet — closing stays on the backdrop/Done/Escape paths.
+ */
+export function useSheetDrag(sheetRef: React.RefObject<HTMLDivElement>) {
+    const dragRef = useRef<DragState | null>(null);
+
+    // If the viewport shrinks (rotation, split view) while a dragged height is
+    // pinned, re-clamp so the sheet top can't end up above the screen.
+    useEffect(() => {
+        const onResize = () => {
+            const el = sheetRef.current;
+            if (!el || !el.style.height) return;
+            const max = window.innerHeight * SHEET_MAX_VIEWPORT_FRACTION;
+            if (parseFloat(el.style.height) > max) el.style.height = `${max}px`;
+        };
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, [sheetRef]);
+
+    const onPointerDown = useCallback(
+        (e: React.PointerEvent<HTMLElement>) => {
+            const el = sheetRef.current;
+            if (!el) return;
+            dragRef.current = {
+                pointerId: e.pointerId,
+                startY: e.clientY,
+                startHeight: el.getBoundingClientRect().height,
+            };
+            try {
+                // Keep receiving moves after the pointer leaves the handle.
+                e.currentTarget.setPointerCapture(e.pointerId);
+            } catch {
+                // Capture is an enhancement; synthetic events have no active
+                // pointer to capture.
+            }
+        },
+        [sheetRef],
+    );
+
+    const onPointerMove = useCallback(
+        (e: React.PointerEvent<HTMLElement>) => {
+            const drag = dragRef.current;
+            const el = sheetRef.current;
+            if (!drag || !el || e.pointerId !== drag.pointerId) return;
+            const max = window.innerHeight * SHEET_MAX_VIEWPORT_FRACTION;
+            const next = Math.min(
+                max,
+                Math.max(SHEET_MIN_HEIGHT, drag.startHeight + (drag.startY - e.clientY)),
+            );
+            // Mutate the style directly — re-rendering the whole sheet on
+            // every pointermove would jank the drag on low-end phones.
+            el.style.height = `${next}px`;
+            el.style.maxHeight = "none";
+        },
+        [sheetRef],
+    );
+
+    const endDrag = useCallback((e: React.PointerEvent<HTMLElement>) => {
+        if (dragRef.current?.pointerId !== e.pointerId) return;
+        dragRef.current = null;
+        try {
+            if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+                e.currentTarget.releasePointerCapture(e.pointerId);
+            }
+        } catch {
+            // Mirror of the capture guard above.
+        }
+    }, []);
+
+    return { onPointerDown, onPointerMove, onPointerUp: endDrag, onPointerCancel: endDrag };
+}


### PR DESCRIPTION
## Summary

Makes the app usable on phones and tablets: below a 900px breakpoint the floating desktop chrome reorganizes into touch-first bottom sheets with drag-to-resize grab handles, while the desktop layout stays pixel-identical.

## Motivation

The UI was desktop-only: the 220px category panel collided with the ~380px centered time controls on narrow screens, the 360px detail panel covered (or exceeded) a phone viewport, `100vh` hid the legend behind iOS Safari's toolbar, tap targets were ~22px, and the tooltip is a hover-only concept. No tracking issue — direct maintainer request.

Closes #N/A

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (behavior or API shape changes in a way a consumer would notice)
- [ ] Data-pipeline change (SQL migration, view, or export)
- [ ] Docs / chore / refactor (no runtime behavior change)
- [ ] CI / tooling

## What changed

- New `useMediaQuery` hook (`useSyncExternalStore`-based) with `useIsMobile` (≤900px) and `useIsCoarsePointer` (`hover: none`) variants; breakpoint chosen so iPad portrait gets the touch layout and iPad landscape keeps desktop chrome
- Mobile: the four floating control groups (category / geography / metric / time) collapse into a new `FilterSheet` bottom sheet opened from a header **Filters** button, with 40–44px touch chips; selections apply live, same as desktop
- Mobile: `DetailPanel` becomes a bottom sheet; the map above it stays interactive so tapping another region swaps content in place
- Both sheets have a functional grab handle (`SheetHandle` + `useSheetDrag`): dragging resizes between 140px and 92% of the viewport via direct style mutation (no per-pointermove re-renders); dismissal stays on backdrop / Done / ✕ / Escape only
- Map: fits CONUS bounds on small screens instead of the desktop center/zoom, disables touch rotation/pitch (compass is hidden, so a rotated map would be unfixable), skips zoom buttons on touch devices
- Viewport correctness: `dvh`-with-`vh`-fallback utility classes, `viewport-fit=cover` + safe-area insets on bottom-anchored UI, `touch-action: manipulation`
- Details: hover tooltip suppressed on touch, hint reads "Tap any region" and moves top-center, compact legend, modal padding tightened, header subtitle hidden with title ellipsized
- Shared option lists (`METRIC_OPTIONS`, `MONTH_OPTIONS`) lifted into constants so desktop controls and the sheet don't duplicate them
- 9 new unit tests (`useMediaQuery`: 4, `useSheetDrag`: 5)

## Alternatives considered and not picked

- **CSS media queries in index.css** instead of a JS hook: the codebase styles exclusively via inline style objects, so class-based responsive overrides would have meant a parallel styling system; the hook keeps the existing idiom. CSS classes are used only where inline styles can't express duplicate-property `vh`→`dvh` fallbacks.
- **Drag-to-dismiss on the sheets** (flick down to close): kept dismissal on backdrop/Done/Escape only, per the requested behavior — dragging purely resizes, clamped at a 140px minimum.
- **React state per pointermove for drag**: rejected; re-rendering ~50 chips at 60Hz janks low-end phones. The hook mutates `style.height` directly and React never reconciles it away (verified across open/close cycles).
- **768px breakpoint**: at 768–850px the centered time control overlaps the category panel, so desktop chrome only activates above 900px.

## Screenshots / recordings

| Before | After |
| ------ | ----- |
| Desktop-only layout; controls overlap/overflow at phone widths | Mobile 375×812: header with Filters button, full-width filter sheet with touch chips, drag-resizable; desktop 1280×800 unchanged |

Screenshots were captured during preview verification but can't be attached via CLI — happy to add them to the PR from the browser.

## Data-pipeline checklist

N/A — no changes to `scripts/` or `public/data/`.

## Pre-merge checklist

- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` reports no errors
- [x] Happy path clicked through in a browser (state → ZIP3 → year → month → category → close panel)
- [x] No `console.log` debug statements in shipped code
- [x] No unused imports, types, or dead files
- [ ] README, ARCHITECTURE, or an ADR updated if load-bearing behavior changed
- [x] Accessibility: interactive controls reachable by keyboard; contrast meets WCAG AA
- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) has been read

## Reviewer notes

- Drag behavior was verified by dispatching real pointer-event sequences in a 375×812 preview: −200px drag shrank the sheet exactly 200px, upward drag clamped at 92% of viewport, extreme downward drag clamped at 140px with the sheet still open, and backdrop/Done still dismiss.
- The docs checkbox is unchecked deliberately: ARCHITECTURE.md §4 (frontend) could gain a short "responsive layout" note; happy to add here or as a follow-up.
- Worth scrutiny: `useSheetDrag` clamps against `window.innerHeight` (layout viewport) rather than `visualViewport` — acceptable drift when the mobile toolbar collapses, but flag if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile filter sheet for touch devices with drag-to-resize bottom sheet interface.
  * Responsive layouts for mobile devices, including adaptive modals and detail panels.

* **Bug Fixes**
  * Improved handling of display cutouts on modern mobile devices.
  * Better touch device support by disabling navigation controls on coarse-pointer devices to prevent gesture conflicts.

* **Accessibility**
  * Added descriptive label to detail panel close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->