### PR TITLE
Add tooth emoji favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
         />
         <meta name="robots" content="index,follow" />
         <meta name="theme-color" content="#f5f3ef" />
+        <link
+            rel="icon"
+            href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>%F0%9F%A6%B7</text></svg>"
+        />
         <title>Medicaid Dental Utilization · United States</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Sets the site favicon to a tooth emoji (🦷), fitting for a Medicaid dental utilization site.

The page previously had no favicon at all, so browsers fell back to a missing `/favicon.ico`. This adds a `<link rel="icon">` using an inline SVG data URI that renders the emoji as text — no binary icon asset required, and it uses each viewer's native OS emoji.

## Changes

- `index.html`: add inline SVG data-URI favicon (`🦷`)

## Verification

- `npm install` + `vite build` succeed; the data URI is preserved intact in the emitted `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J51AWjF1nRP117sJHDZ9SD)_