### PR TITLE
Update CHOMP site and repository URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
       label: Steps to reproduce
       description: Minimal sequence of actions that triggers the bug.
       value: |
-        1. Open https://erovelli.github.io/medicaid-dent-policy/
+        1. Open the Harvard production site at https://chomp.share.library.harvard.edu/
         2. Click on …
         3. Select …
         4. Observe …
@@ -54,7 +54,7 @@ body:
     attributes:
       label: URL (if applicable)
       description: A deep link or snapshot URL where the bug is visible.
-      placeholder: https://erovelli.github.io/medicaid-dent-policy/
+      placeholder: https://chomp.share.library.harvard.edu/
 
   - type: dropdown
     id: browser
@@ -104,5 +104,5 @@ body:
       options:
         - label: I searched existing issues and did not find a duplicate.
           required: true
-        - label: I can reproduce this on the latest deployed version.
+        - label: I can reproduce this on the Harvard production site or have identified the staging site in the URL field.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/erovelli/medicaid-dent-policy/security/advisories/new
+    url: https://github.com/erovelli/CHOMP/security/advisories/new
     about: Report a security issue privately via GitHub Security Advisories. Do not open a public issue.
   - name: Project documentation
-    url: https://github.com/erovelli/medicaid-dent-policy/blob/main/docs/ARCHITECTURE.md
+    url: https://github.com/erovelli/CHOMP/blob/main/docs/ARCHITECTURE.md
     about: Architecture and design notes — most "why does it work this way" questions are answered here.
   - name: HHS Medicaid source data
     url: https://data.cms.gov/

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,8 +7,8 @@ body:
     attributes:
       value: |
         Most "why is it built this way" questions are answered in
-        [`docs/ARCHITECTURE.md`](https://github.com/erovelli/medicaid-dent-policy/blob/main/docs/ARCHITECTURE.md)
-        and the [ADRs](https://github.com/erovelli/medicaid-dent-policy/tree/main/docs/adr).
+        [`docs/ARCHITECTURE.md`](https://github.com/erovelli/CHOMP/blob/main/docs/ARCHITECTURE.md)
+        and the [ADRs](https://github.com/erovelli/CHOMP/tree/main/docs/adr).
         Please skim those first.
 
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - name: Build
         env:
+          BASE_PATH: /CHOMP/
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
         run: npm run build
       - name: Check bundle size

--- a/.github/workflows/deploy-share.yml
+++ b/.github/workflows/deploy-share.yml
@@ -1,6 +1,6 @@
 # Deploy to Harvard SHARE (cPanel shared hosting) over SSH.
 #
-# Target: https://molar.share.library.harvard.edu, served from the domain root.
+# Production target: https://chomp.share.library.harvard.edu/, served from the domain root.
 # The cPanel account name and docroot are NOT recorded here — they are sensitive and
 # live only in the SSH_HOST / SSH_PATH secrets. Do not paste either into this file,
 # into commit messages, or into log output. The public hostname above is fine.
@@ -25,11 +25,11 @@
 #     hand-installed gzip-rewrite and pmtiles rules. It is excluded from the rsync and
 #     must never be overwritten from the repo.
 #
-#   * BASE_PATH is "/" here (domain root) and "/medicaid-dent-policy/" for GitHub
-#     Pages, which is also the vite.config.ts fallback. A plain `npm run build` here
+#   * BASE_PATH is "/" here (domain root) and "/CHOMP/" for the GitHub Pages
+#     staging site, which is also the vite.config.ts fallback. A plain `npm run build` here
 #     silently produces a Pages-based site where every asset 404s, so the build is
 #     asserted below rather than trusted.
-name: Deploy to SHARE
+name: Deploy production to Harvard SHARE
 
 on:
   push:
@@ -49,7 +49,7 @@ permissions: {}
 
 jobs:
   build:
-    name: Build for SHARE
+    name: Build for Harvard production
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -87,14 +87,11 @@ jobs:
             exit 1
           fi
 
-          # Match the slash-delimited base path, not the bare repo name: the export
-          # footer in src/lib/export/synthesizeMap.ts contains the literal string
-          # "medicaid-dent-policy · …", so a bare grep would fail every correct build.
-          # A real leak always emits "/medicaid-dent-policy/" (fetch URLs, pmtiles://
-          # URLs, the modulepreload prefix).
-          if grep -rq '/medicaid-dent-policy/' dist/assets/; then
-            echo "::error::Pages base path leaked into dist/assets/ — every asset would 404 on SHARE."
-            grep -rl '/medicaid-dent-policy/' dist/assets/ || true
+          # A staging-path leak emits "/CHOMP/" in fetch URLs, pmtiles:// URLs, or
+          # modulepreload prefixes. Those URLs would 404 at the production domain root.
+          if grep -rq '/CHOMP/' dist/assets/; then
+            echo "::error::Staging base path leaked into dist/assets/ — every asset would 404 in production."
+            grep -rl '/CHOMP/' dist/assets/ || true
             exit 1
           fi
 
@@ -126,7 +123,7 @@ jobs:
           if-no-files-found: error
 
   deploy:
-    name: Deploy to SHARE
+    name: Deploy to Harvard production
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -275,7 +272,7 @@ jobs:
           echo "Docroot OK"
 
           # .htaccess is excluded from the sync, so if it ever vanishes the deploy would
-          # succeed while the live site breaks (no DirectoryIndex, no gzip/pmtiles rules).
+          # succeed while the Harvard production site breaks (no DirectoryIndex, no gzip/pmtiles rules).
           [ -f "$SSH_PATH/.htaccess" ] || { echo "::error::.htaccess is missing from the docroot. It is server-managed and excluded from the sync; restore it on the server before deploying."; exit 1; }
           echo ".htaccess OK"
 
@@ -310,10 +307,10 @@ jobs:
             dist/ "$SSH_HOST:$SSH_PATH/"
 
       # Static files on Apache are live the instant rsync finishes — no propagation wait.
-      - name: Verify live site
+      - name: Verify Harvard production site
         if: ${{ inputs.dry_run != true }}
         env:
-          SITE_URL: https://molar.share.library.harvard.edu
+          SITE_URL: https://chomp.share.library.harvard.edu
         run: |
           set -euo pipefail
           failed=0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy staging
 
 on:
   push:
@@ -36,6 +36,7 @@ jobs:
 
       - name: Build
         env:
+          BASE_PATH: /CHOMP/
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
         run: npm run build
 
@@ -60,7 +61,7 @@ jobs:
           if-no-files-found: error
 
   deploy:
-    name: Deploy to GitHub Pages
+    name: Deploy staging to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -70,7 +71,7 @@ jobs:
 
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: https://erovel.li/CHOMP/
 
     steps:
       - name: Deploy

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Build
         env:
+          BASE_PATH: /CHOMP/
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
         run: npm run build
 

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -4,7 +4,7 @@
       "startServerCommand": "npm run preview -- --port 4173 --strictPort",
       "startServerReadyPattern": "Local:",
       "startServerReadyTimeout": 30000,
-      "url": ["http://localhost:4173/medicaid-dent-policy/"],
+      "url": ["http://localhost:4173/CHOMP/"],
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,17 +50,17 @@ Small PRs are welcomed without a tracking issue. Anything that changes behavior,
 nvm use                   # Node 20.x (see .nvmrc)
 npm install
 cp .env.example .env.local # add VITE_PROTOMAPS_API_KEY if available
-npm run dev               # http://localhost:5173/medicaid-dent-policy/
+npm run dev               # http://localhost:5173/CHOMP/
 ```
 
 Useful scripts:
 
-| Command           | Purpose                                                                    |
-| ----------------- | -------------------------------------------------------------------------- |
-| `npm run dev`     | Vite dev server with HMR.                                                  |
-| `npm run build`   | Production build (`tsc && vite build`). This is the command CI runs.       |
-| `npm run preview` | Serve the production build locally.                                        |
-| `npm run deploy`  | Publish `dist/` to the `gh-pages` branch. Requires maintainer permissions. |
+| Command           | Purpose                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `npm run dev`     | Vite dev server with HMR.                                                          |
+| `npm run build`   | Production build (`tsc && vite build`). This is the command CI runs.               |
+| `npm run preview` | Serve the production build locally.                                                |
+| `npm run deploy`  | Publish `dist/` to the GitHub Pages staging site. Requires maintainer permissions. |
 
 **Editor setup:** the repo ships with an [`.editorconfig`](.editorconfig) that pins indentation and line endings. Recommended VS Code extensions: TypeScript, EditorConfig for VS Code, ESLint (once added).
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@
 
 A full-stack data visualization project that transforms ~60 GB of raw HHS Open Data and NPPES records into an interactive map — state-, county-, and ZIP3-level utilization across all 12 CDT/ADA dental procedure categories, six years of history, and monthly drill-down.
 
-[**→ Open the live site**](https://erovelli.github.io/medicaid-dent-policy/)
+[**→ Open the Harvard production site**](https://chomp.share.library.harvard.edu/)
 
-[![CI](https://github.com/erovelli/medicaid-dent-policy/actions/workflows/ci.yml/badge.svg)](https://github.com/erovelli/medicaid-dent-policy/actions/workflows/ci.yml)
-[![Deploy](https://github.com/erovelli/medicaid-dent-policy/actions/workflows/deploy.yml/badge.svg)](https://github.com/erovelli/medicaid-dent-policy/actions/workflows/deploy.yml)
+[Test changes on the GitHub Pages staging site](https://erovel.li/CHOMP/)
+
+[![CI](https://github.com/erovelli/CHOMP/actions/workflows/ci.yml/badge.svg)](https://github.com/erovelli/CHOMP/actions/workflows/ci.yml)
+[![Production deploy](https://github.com/erovelli/CHOMP/actions/workflows/deploy-share.yml/badge.svg)](https://github.com/erovelli/CHOMP/actions/workflows/deploy-share.yml)
+[![Staging deploy](https://github.com/erovelli/CHOMP/actions/workflows/deploy.yml/badge.svg)](https://github.com/erovelli/CHOMP/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-informational.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.json)
 [![React 18](https://img.shields.io/badge/React-18-61dafb.svg)](https://react.dev)
@@ -93,17 +96,17 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the long-form write-up, i
 
 ## Stack & rationale
 
-| Layer           | Choice                                           | Why                                                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Renderer**    | MapLibre GL JS                                   | GPU-accelerated, hardware-composited vector tiles; supports `setFeatureState` for per-feature updates without rebuilding sources.                                                                                       |
-| **Tile format** | [PMTiles](https://protomaps.com/docs/pmtiles) v3 | Single-file vector tiles served over static HTTPS with range requests — no tile server to run.                                                                                                                          |
-| **Basemap**     | Protomaps                                        | Paid-tier vector basemap (key in `.env.local`); gracefully degrades to a blank background when no key is present.                                                                                                       |
-| **Framework**   | React 18 + Vite 5                                | Fast HMR; `React.StrictMode` in dev catches double-mount regressions in the map lifecycle.                                                                                                                              |
-| **Language**    | TypeScript `strict`                              | Every layer is typed end-to-end: `LayerKey` union ↔ `LAYER_CONFIGS` record enforces exhaustiveness at compile time.                                                                                                     |
-| **State**       | [Zustand](https://zustand-demo.pmnd.rs/)         | Single small store with selector-hooks; avoids the provider-tree churn a Context-based solution would introduce in a map app that re-renders on every hover event.                                                      |
-| **Data shape**  | NDJSON of `{ key: records[] }` objects           | Streamable, append-only, gzips well. The browser consumes all four files through a single `fetchNDJSON` helper.                                                                                                         |
-| **Pipeline**    | Python + DuckDB                                  | Python runs the HHS×NPPES merge (`merge_hhs_nppes.py`) and the geocoded-CSV join (`join_geocoded.py`); `build_aggregates.py` runs DuckDB over the merged CSV and writes the six NDJSON files. No database to provision. |
-| **Hosting**     | GitHub Pages (static)                            | Zero-infra. The site is ~6 MB gzipped including both PMTiles archives.                                                                                                                                                  |
+| Layer           | Choice                                              | Why                                                                                                                                                                                                                     |
+| --------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Renderer**    | MapLibre GL JS                                      | GPU-accelerated, hardware-composited vector tiles; supports `setFeatureState` for per-feature updates without rebuilding sources.                                                                                       |
+| **Tile format** | [PMTiles](https://protomaps.com/docs/pmtiles) v3    | Single-file vector tiles served over static HTTPS with range requests — no tile server to run.                                                                                                                          |
+| **Basemap**     | Protomaps                                           | Paid-tier vector basemap (key in `.env.local`); gracefully degrades to a blank background when no key is present.                                                                                                       |
+| **Framework**   | React 18 + Vite 5                                   | Fast HMR; `React.StrictMode` in dev catches double-mount regressions in the map lifecycle.                                                                                                                              |
+| **Language**    | TypeScript `strict`                                 | Every layer is typed end-to-end: `LayerKey` union ↔ `LAYER_CONFIGS` record enforces exhaustiveness at compile time.                                                                                                     |
+| **State**       | [Zustand](https://zustand-demo.pmnd.rs/)            | Single small store with selector-hooks; avoids the provider-tree churn a Context-based solution would introduce in a map app that re-renders on every hover event.                                                      |
+| **Data shape**  | NDJSON of `{ key: records[] }` objects              | Streamable, append-only, gzips well. The browser consumes all four files through a single `fetchNDJSON` helper.                                                                                                         |
+| **Pipeline**    | Python + DuckDB                                     | Python runs the HHS×NPPES merge (`merge_hhs_nppes.py`) and the geocoded-CSV join (`join_geocoded.py`); `build_aggregates.py` runs DuckDB over the merged CSV and writes the six NDJSON files. No database to provision. |
+| **Hosting**     | Harvard SHARE (production) + GitHub Pages (staging) | The same static bundle is deployed at the domain root in production and under `/CHOMP/` in staging. The site is ~6 MB gzipped including both PMTiles archives.                                                          |
 
 ## Engineering highlights
 
@@ -127,15 +130,15 @@ A few decisions worth calling out in a code review:
 ### Run locally
 
 ```bash
-git clone https://github.com/erovelli/medicaid-dent-policy.git
-cd medicaid-dent-policy
+git clone https://github.com/erovelli/CHOMP.git
+cd CHOMP
 nvm use           # or ensure Node 20
 npm install
 echo "VITE_PROTOMAPS_API_KEY=your_key_here" > .env.local
 npm run dev
 ```
 
-Open http://localhost:5173/medicaid-dent-policy/ (note the base path — configured for GitHub Pages).
+Open http://localhost:5173/CHOMP/ (note the base path — configured to match the staging site).
 
 ### Scripts
 
@@ -150,7 +153,7 @@ Open http://localhost:5173/medicaid-dent-policy/ (note the base path — configu
 | `npm test` / `npm run test:watch`         | Vitest unit suite.                                                   |
 | `npm run test:coverage`                   | Vitest + V8 coverage report.                                         |
 | `npm run size`                            | `size-limit` check against the gzipped bundle budget.                |
-| `npm run deploy`                          | Publish `dist/` to the `gh-pages` branch.                            |
+| `npm run deploy`                          | Publish `dist/` to the GitHub Pages staging site.                    |
 
 A Husky pre-commit hook runs `lint-staged` (ESLint + Prettier on staged files). Install it the first time with `npm install` — `husky` auto-registers the hook via the `prepare` script.
 
@@ -187,17 +190,22 @@ No database to provision.
 
 ### Deploy
 
-CI publishes to GitHub Pages on every push to `main` (see [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)). For a manual push:
+Every push to `main` deploys the same source to two static environments:
+
+- **Production:** Harvard SHARE at <https://chomp.share.library.harvard.edu/> via [`.github/workflows/deploy-share.yml`](.github/workflows/deploy-share.yml), built with `BASE_PATH=/`.
+- **Staging/test:** GitHub Pages at <https://erovel.li/CHOMP/> via [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml), built with `BASE_PATH=/CHOMP/`.
+
+Both workflows support manual dispatch from GitHub Actions. The local `gh-pages` command is a staging-only fallback:
 
 ```bash
 npm run build
-npm run deploy    # gh-pages branch
+npm run deploy    # staging only
 ```
 
 ## Project layout
 
 ```
-medicaid-dent-policy/
+CHOMP/
 ├── src/
 │   ├── App.tsx                    # Shell: header + map + floating UI
 │   ├── main.tsx                   # React entry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ The NDJSON files and `.pmtiles` archives are the **interface contract** between 
 
 This is the single most consequential architectural decision in the project, and it flows from two constraints:
 
-1. **Cost.** Zero-dollar hosting was a hard requirement.
+1. **Operations.** Production on Harvard SHARE and staging on GitHub Pages both serve the same static bundle, so there is no application server to provision or operate.
 2. **Privacy.** The source data is public but a live backend would expose query patterns that the suppression rules (<12 claims / <12 beneficiaries per cell) are designed to prevent. Pre-aggregating at build time means only the published aggregations are accessible.
 
 ## 3. Data pipeline

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -197,7 +197,7 @@ The script also runs integrity checks — no unused geocoded addresses, and per-
 
 **Issue.** Adult Medicaid dental benefits vary dramatically by state: from comprehensive (NY, CA) to emergency-only (TN, AL) to none (DE). Pediatric coverage is more uniform (federally mandated under EPSDT).
 **Impact.** Raw claim counts and dollars are not comparable across states for adult dental services. A "low" map value in TN reflects benefit policy, not lack of need.
-**Mitigation.** Already surfaced in the InfoModal on the live site. Worth a paragraph in any policy interpretation of the map.
+**Mitigation.** Already surfaced in the InfoModal on the Harvard production site. Worth a paragraph in any policy interpretation of the map.
 
 ### L21 ⬜ Indian Health Service / tribal dental
 

--- a/docs/adr/0001-static-site-no-backend.md
+++ b/docs/adr/0001-static-site-no-backend.md
@@ -20,7 +20,7 @@ This shape is familiar and flexible. It is also:
 
 ## Decision
 
-Ship the site as a **static bundle**. All data aggregations happen offline at build time (Python + DuckDB), are exported to NDJSON + PMTiles + GeoJSON, and are served as static files from GitHub Pages. No server-side rendering, no API, no auth, no database — at build time or runtime.
+Ship the site as a **static bundle**. All data aggregations happen offline at build time (Python + DuckDB), are exported to NDJSON + PMTiles + GeoJSON, and are served as static files. The Harvard SHARE host serves production at <https://chomp.share.library.harvard.edu/>; GitHub Pages serves staging at <https://erovel.li/CHOMP/>. No server-side rendering, no API, no auth, no database — at build time or runtime.
 
 > Earlier revisions of this ADR described a Postgres view chain as the build-time aggregator. That stack was retired once DuckDB became the authoritative aggregator (zero-setup, ~10s over the 23M-row CSV) and the SQL was never actually executed in any environment. The "no backend" decision below is unchanged; only the offline build tooling differs.
 
@@ -28,7 +28,7 @@ Ship the site as a **static bundle**. All data aggregations happen offline at bu
 
 **Positive**
 
-- **$0 hosting.** GitHub Pages absorbs the traffic.
+- **No application server.** Harvard SHARE serves the production static bundle, and GitHub Pages hosts an independently deployable staging copy.
 - **Privacy by construction.** Only the published aggregations are accessible. No query can exceed that surface.
 - **Trivial CDN story.** Static files → global edge caches for free.
 - **Reproducible.** Every artifact in `public/data/` corresponds to a specific commit of `scripts/build_aggregates.py` plus the input CSV. Rebuilding is a single `python` invocation.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         />
         <meta name="robots" content="index,follow" />
         <meta name="theme-color" content="#f5f3ef" />
+        <link rel="canonical" href="https://chomp.share.library.harvard.edu/" />
         <link
             rel="icon"
             href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>%F0%9F%A6%B7</text></svg>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chomp",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "d3-geo": "^3.1.1",
         "maplibre-gl": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,17 @@
 {
   "name": "chomp",
   "version": "0.1.0",
+  "description": "Claims History of Oral Healthcare Medicaid Procedures",
+  "license": "MIT",
   "private": true,
+  "homepage": "https://chomp.share.library.harvard.edu/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/erovelli/CHOMP.git"
+  },
+  "bugs": {
+    "url": "https://github.com/erovelli/CHOMP/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.22.1"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -11,7 +11,7 @@ export const NAV_LABELS: Record<NavPage, string> = {
     contact: "Contact",
 };
 
-export const REPO_URL = "https://github.com/erovelli/medicaid-dent-policy";
+export const REPO_URL = "https://github.com/erovelli/CHOMP";
 
 export type PageSection =
     | { kind: "paragraph"; body: string }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// BASE_PATH is set by CI so one source tree can ship to GitHub Pages
-// ("/medicaid-dent-policy/") and to SHARE ("/", the domain root).
-const base = process.env.BASE_PATH ?? "/medicaid-dent-policy/";
+// BASE_PATH is set by CI so one source tree can ship to the GitHub Pages
+// staging site ("/CHOMP/") and the Harvard production site ("/", the domain root).
+const base = process.env.BASE_PATH ?? "/CHOMP/";
 
 export default defineConfig({
     plugins: [react()],


### PR DESCRIPTION
## Summary

- make the Harvard CHOMP site the documented and canonical production environment
- move GitHub Pages staging paths and links to `https://erovel.li/CHOMP/`
- update repository links and package metadata to `erovelli/CHOMP`
- align deployment workflows, local development paths, issue templates, and architecture documentation with the new environment roles

## Impact

Production builds continue to use the domain root through `BASE_PATH=/`. Staging and default local builds now use `/CHOMP/`, preventing broken asset and PMTiles URLs on GitHub Pages. The Harvard production URL is also declared as the canonical site.

## Validation

- `npm run typecheck`
- `npm test -- --reporter=default` — 58 tests passed
- `npm run lint` — passed with two existing console warnings
- `npm run format:check`
- staging build with `BASE_PATH=/CHOMP/`
- production build with `BASE_PATH=/`
- stale-reference scan for former repository and hosting URLs
- direct gzip bundle measurements within configured limits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Production hosting now uses the Harvard site, with GitHub Pages serving as the staging environment.
  * Updated deployment paths and links ensure the site loads correctly at its new `/CHOMP/` address.
* **Documentation**
  * Updated setup, deployment, architecture, and project links to reflect the CHOMP project and its separate production and staging environments.
* **Website**
  * Added a canonical URL to improve site identification and sharing.
* **Project Metadata**
  * Added project, licensing, homepage, repository, and issue-tracker information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->